### PR TITLE
Implement admin-only user registration

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { LoginComponent } from './auth/login/login.component';
+import { RegisterComponent } from './auth/register/register.component';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
 import { AuthGuard } from './auth/guards/auth.guard';
 import { LeadCreateComponent } from './components/lead/lead-create/lead-create.component';
@@ -13,6 +14,12 @@ import {LeadCadastroCompletoComponent} from './components/lead/lead-cadastro-com
 export const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
   { path: 'login', component: LoginComponent },
+  {
+    path: 'register',
+    component: RegisterComponent,
+    canActivate: [AuthGuard],
+    data: { roles: ['ROLE_ADMIN'] }
+  },
   {
     path: 'dashboard',
     component: DashboardComponent,

--- a/src/app/auth/models/user-cadastro.dto.ts
+++ b/src/app/auth/models/user-cadastro.dto.ts
@@ -1,0 +1,8 @@
+export interface UserCadastroDTO {
+  userName: string;
+  nome: string;
+  email: string;
+  telefone: string;
+  password: string;
+  ocupacoes: string[];
+}

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -1,1 +1,12 @@
-<p>register works!</p>
+<form [formGroup]="form" (ngSubmit)="register()">
+  <input formControlName="userName" placeholder="Usuário" />
+  <input formControlName="nome" placeholder="Nome" />
+  <input formControlName="email" placeholder="Email" />
+  <input formControlName="telefone" placeholder="Telefone" />
+  <input formControlName="password" type="password" placeholder="Senha" />
+  <select formControlName="ocupacoes" multiple>
+    <option *ngFor="let r of ocupacoes" [value]="r.value">{{ r.label }}</option>
+  </select>
+  <button type="submit">Cadastrar</button>
+  <div *ngIf="error">{{ error }}</div>
+</form>

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -1,11 +1,46 @@
 import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-register',
-  imports: [],
+  standalone: true,
+  imports: [ReactiveFormsModule, CommonModule],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss'
 })
 export class RegisterComponent {
+  form: FormGroup;
+  error = '';
+  ocupacoes = [
+    { label: 'Administrador', value: 'ROLE_ADMIN' },
+    { label: 'Usuário', value: 'ROLE_USER' },
+    { label: 'Corretor', value: 'ROLE_CORRETOR' },
+    { label: 'Correspondente', value: 'ROLE_CORRESPONDENTE' }
+  ];
 
+  constructor(
+    private fb: FormBuilder,
+    private auth: AuthService,
+    private router: Router
+  ) {
+    this.form = this.fb.group({
+      userName: [''],
+      nome: [''],
+      email: [''],
+      telefone: [''],
+      password: [''],
+      ocupacoes: [[]]
+    });
+  }
+
+  register() {
+    const user = this.form.value;
+    this.auth.register(user).subscribe({
+      next: () => this.router.navigate(['/login']),
+      error: () => this.error = 'Erro ao cadastrar usuário'
+    });
+  }
 }

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -22,6 +22,13 @@ export class AuthService {
     );
   }
 
+  register(user: import('../models/user-cadastro.dto').UserCadastroDTO) {
+    return this.http.post(
+      'http://localhost:8080/api/users',
+      user
+    );
+  }
+
   logout() {
     this.removeToken();
     this.jwtSubject.next(null);

--- a/src/app/components/template/nav/nav.component.ts
+++ b/src/app/components/template/nav/nav.component.ts
@@ -37,7 +37,8 @@ export class NavComponent {
     { label: 'Lista Leads Aptos', icon: 'list', route: '/listCorrespondente', roles: ['ROLE_ADMIN', 'ROLE_CORRESPONDENTE'] },
     { label: 'Criar lead', icon: 'note_add', route: 'lead/completo', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Documentos', icon: 'upload', route: '/leads/documento', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
-    { label: 'Endereco Lead', icon: 'create', route: '/endreco', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] }
+    { label: 'Endereco Lead', icon: 'create', route: '/endreco', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
+    { label: 'Cadastrar Usuário', icon: 'person_add', route: '/register', roles: ['ROLE_ADMIN'] }
   ];
 
   logout() {


### PR DESCRIPTION
## Summary
- restrict registration page to admin role
- remove public register link from login
- add registration menu item for admins
- support role selection when registering users
- add fields for full user registration

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668c3b86588322a212383c25ecf550