### PR TITLE
feat(inspections): add Excel import and listing page for inspections

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,6 +12,9 @@ import {LeadCadastroCompletoComponent} from './components/lead/lead-cadastro-com
 import {RegisterComponent} from './auth/register/register.component';
 import {UserListComponent} from './components/user/user-list/user-list.component';
 import {SolicitarDocumentoComponent} from './components/lead/solicitar-documento/solicitar-documento.component';
+import {
+  InspectionImportListComponent
+} from './components/inspection/inspection-import-list/inspection-import-list.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
@@ -69,5 +72,11 @@ export const routes: Routes = [
     component: UserListComponent,
     canActivate: [AuthGuard],
     data: { roles: ['ROLE_ADMIN'] }
+  },
+  {
+    path: 'inspections',
+    component: InspectionImportListComponent,
+    canActivate: [AuthGuard],
+    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] }
   }
 ];

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
@@ -1,0 +1,66 @@
+<section class="page-wrapper">
+  <h2>Importar inspeções por Excel</h2>
+
+  <div class="import-box mat-elevation-z2">
+    <input type="file" accept=".xlsx,.xls" (change)="onFileSelected($event)" />
+
+    <button mat-raised-button color="primary" (click)="importExcel()" [disabled]="isLoading">
+      <mat-icon>upload_file</mat-icon>
+      Importar planilha
+    </button>
+
+    <span class="file-name" *ngIf="selectedFile">{{ selectedFile.name }}</span>
+  </div>
+
+  <mat-form-field appearance="outline" class="filter-field">
+    <mat-label>Buscar inspeções</mat-label>
+    <input matInput (keyup)="applyFilter($event)" placeholder="Status, cliente, cidade..." />
+    <button mat-icon-button matSuffix *ngIf="dataSource.filter" (click)="clearFilter()" aria-label="Limpar filtro">
+      <mat-icon>close</mat-icon>
+    </button>
+  </mat-form-field>
+
+  <div class="table-wrapper mat-elevation-z2">
+    <table mat-table [dataSource]="dataSource" matSort>
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
+        <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
+        <td mat-cell *matCellDef="let row">{{ row.status || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="worder">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Work order</th>
+        <td mat-cell *matCellDef="let row">{{ row.worder || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="client">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Cliente</th>
+        <td mat-cell *matCellDef="let row">{{ row.client || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Nome</th>
+        <td mat-cell *matCellDef="let row">{{ row.name || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="city">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Cidade</th>
+        <td mat-cell *matCellDef="let row">{{ row.city || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="duedate">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Due date</th>
+        <td mat-cell *matCellDef="let row">{{ row.duedate || '-' }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    <mat-paginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25]" aria-label="Paginação"></mat-paginator>
+  </div>
+</section>

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
@@ -1,0 +1,34 @@
+.page-wrapper {
+  padding: 16px;
+}
+
+.import-box {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  margin: 16px 0;
+  background: #fff;
+  border-radius: 8px;
+}
+
+.file-name {
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.filter-field {
+  width: min(420px, 100%);
+  margin-bottom: 12px;
+}
+
+.table-wrapper {
+  overflow: auto;
+  background: #fff;
+  border-radius: 8px;
+}
+
+table {
+  width: 100%;
+  min-width: 800px;
+}

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
@@ -1,0 +1,138 @@
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { finalize } from 'rxjs';
+
+import { Inspection } from '../../../models/inspection.model';
+import { InspectionService } from '../inspection.service';
+
+@Component({
+  selector: 'app-inspection-import-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSnackBarModule
+  ],
+  templateUrl: './inspection-import-list.component.html',
+  styleUrl: './inspection-import-list.component.scss'
+})
+export class InspectionImportListComponent implements AfterViewInit {
+  displayedColumns: string[] = [
+    'id',
+    'status',
+    'worder',
+    'client',
+    'name',
+    'city',
+    'duedate'
+  ];
+  dataSource = new MatTableDataSource<Inspection>([]);
+  selectedFile?: File;
+  isLoading = false;
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(
+    private inspectionService: InspectionService,
+    private snackBar: MatSnackBar
+  ) {
+    this.dataSource.filterPredicate = (data: Inspection, filter: string) => {
+      const search = filter.trim().toLowerCase();
+      return [
+        data.status,
+        data.worder,
+        data.client,
+        data.name,
+        data.city,
+        data.duedate,
+        data.inspector
+      ]
+        .filter(Boolean)
+        .some((value) => value!.toLowerCase().includes(search));
+    };
+  }
+
+  ngAfterViewInit(): void {
+    this.loadInspections();
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedFile = input.files?.[0];
+  }
+
+  importExcel(): void {
+    if (!this.selectedFile) {
+      this.showMessage('Selecione um arquivo Excel (.xlsx ou .xls).');
+      return;
+    }
+
+    this.isLoading = true;
+    this.inspectionService
+      .uploadExcel(this.selectedFile)
+      .pipe(finalize(() => (this.isLoading = false)))
+      .subscribe({
+        next: () => {
+          this.showMessage('Arquivo importado com sucesso!');
+          this.selectedFile = undefined;
+          this.loadInspections();
+        },
+        error: () => {
+          this.showMessage('Falha ao importar arquivo. Verifique o layout e tente novamente.');
+        }
+      });
+  }
+
+  loadInspections(): void {
+    this.isLoading = true;
+    this.inspectionService
+      .list()
+      .pipe(finalize(() => (this.isLoading = false)))
+      .subscribe({
+        next: (inspections) => {
+          this.dataSource.data = inspections;
+          this.dataSource.paginator = this.paginator;
+          this.dataSource.sort = this.sort;
+        },
+        error: () => {
+          this.showMessage('Não foi possível carregar as inspeções.');
+        }
+      });
+  }
+
+  applyFilter(event: Event): void {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+
+    if (this.dataSource.paginator) {
+      this.dataSource.paginator.firstPage();
+    }
+  }
+
+  clearFilter(): void {
+    this.dataSource.filter = '';
+  }
+
+  private showMessage(message: string): void {
+    this.snackBar.open(message, 'Fechar', {
+      duration: 3500,
+      verticalPosition: 'top',
+      horizontalPosition: 'right'
+    });
+  }
+}

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Inspection } from '../../models/inspection.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class InspectionService {
+  private readonly apiUrl = 'http://localhost:8080/api/inspections';
+
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<Inspection[]> {
+    return this.http.get<Inspection[]>(this.apiUrl);
+  }
+
+  uploadExcel(file: File): Observable<void> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return this.http.post<void>(`${this.apiUrl}/import`, formData);
+  }
+}

--- a/src/app/components/template/nav/nav.component.ts
+++ b/src/app/components/template/nav/nav.component.ts
@@ -37,6 +37,7 @@ export class NavComponent {
     { label: 'Lista Leads Aptos', icon: 'list', route: '/listCorrespondente', roles: ['ROLE_ADMIN', 'ROLE_CORRESPONDENTE'] },
     { label: 'Criar lead', icon: 'note_add', route: 'lead/completo', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Documentos', icon: 'upload', route: '/leads/documento', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
+    { label: 'Inspeções', icon: 'fact_check', route: '/inspections', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Endereco Lead', icon: 'create', route: '/endreco', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Usuários', icon: 'people', route: '/users', roles: ['ROLE_ADMIN'] },
     { label: 'Cadastrar Usuário', icon: 'person_add', route: '/register', roles: ['ROLE_ADMIN'] }  ];

--- a/src/app/models/inspection.model.ts
+++ b/src/app/models/inspection.model.ts
@@ -1,0 +1,30 @@
+export interface Inspection {
+  id: number;
+  inspetorId?: number | null;
+  status?: string | null;
+  worder?: string | null;
+  inspector?: string | null;
+  client?: string | null;
+  name?: string | null;
+  address1?: string | null;
+  address2?: string | null;
+  city?: string | null;
+  zip?: string | null;
+  otype?: string | null;
+  duedate?: string | null;
+  rush?: string | null;
+  followup?: string | null;
+  vacant?: string | null;
+  mortgage?: string | null;
+  vandalism?: string | null;
+  freezeFlag?: string | null;
+  storm?: string | null;
+  roof?: string | null;
+  water?: string | null;
+  naturalFlag?: string | null;
+  fire?: string | null;
+  hazard?: string | null;
+  structure?: string | null;
+  mold?: string | null;
+  pump?: string | null;
+}


### PR DESCRIPTION
### Motivation

- Provide a UI to import inspections from an Excel file and to view the existing inspections in the same page.  
- Allow inspectors/admins to upload spreadsheet data to be processed by the backend and quickly inspect the imported records.  
- Integrate the new feature into the protected app routes and the side navigation for relevant roles.

### Description

- Add `Inspection` interface at `src/app/models/inspection.model.ts` to type inspection payloads used by the UI.  
- Implement `InspectionService` at `src/app/components/inspection/inspection.service.ts` providing `list()` (GET `/api/inspections`) and `uploadExcel(file)` (POST `/api/inspections/import`) methods.  
- Create a standalone `InspectionImportListComponent` under `src/app/components/inspection/inspection-import-list/` with file picker + import action, snackbar feedback, client-side filter, sortable & paginated material table, and responsive styles.  
- Register a protected route `/inspections` and add an "Inspeções" item to the side navigation for `ROLE_ADMIN` and `ROLE_CORRETOR` users.

### Testing

- Ran `npm run build -- --configuration development` which completed successfully.  
- Ran `npm run build` which failed in this environment due to Google Fonts inlining returning HTTP 403 (environment limitation), not related to the feature code.  
- Started the dev server with `npm run start -- --host 0.0.0.0 --port 4200` and validated the page served and hot-reloaded successfully.  
- Executed a Playwright script that set a fake JWT in `localStorage`, navigated to `/inspections` and captured a screenshot (`artifacts/inspections-page.png`) to validate the new UI rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698be96aca688322810717d1e3109d91)