### PR TITLE
Separa cadastro de inspetor em menu próprio e alinha ações

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -77,6 +77,12 @@ export const routes: Routes = [
     path: 'inspections',
     component: InspectionImportListComponent,
     canActivate: [AuthGuard],
-    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] }
+    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], view: 'inspections' }
+  },
+  {
+    path: 'inspectors',
+    component: InspectionImportListComponent,
+    canActivate: [AuthGuard],
+    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], view: 'inspectors' }
   }
 ];

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
@@ -1,181 +1,180 @@
 <section class="page-wrapper">
-  <h2>Gestão de inspeções</h2>
+  <h2 *ngIf="viewMode === 'inspections'">Gestão de inspeções</h2>
+  <h2 *ngIf="viewMode === 'inspectors'">Cadastro de inspetor</h2>
 
-  <mat-tab-group>
-    <mat-tab label="Inspeções">
-      <div class="tab-content">
-        <div class="import-box mat-elevation-z2">
-          <input type="file" accept=".xlsx,.xls" (change)="onFileSelected($event)" />
+  <div *ngIf="viewMode === 'inspections'" class="page-content">
+    <div class="import-box mat-elevation-z2">
+      <input type="file" accept=".xlsx,.xls" (change)="onFileSelected($event)" />
 
-          <button mat-raised-button color="primary" (click)="importExcel()" [disabled]="isLoading">
-            <mat-icon>upload_file</mat-icon>
-            Importar planilha
-          </button>
+      <button mat-raised-button color="primary" (click)="importExcel()" [disabled]="isLoading">
+        <mat-icon>upload_file</mat-icon>
+        Importar planilha
+      </button>
 
-          <span class="file-name" *ngIf="selectedFile">{{ selectedFile.name }}</span>
-        </div>
+      <span class="file-name" *ngIf="selectedFile">{{ selectedFile.name }}</span>
+    </div>
 
-        <mat-form-field appearance="outline" class="filter-field">
-          <mat-label>Buscar inspeções</mat-label>
-          <input matInput (keyup)="applyInspectionFilter($event)" placeholder="Status, cliente, cidade..." />
-          <button mat-icon-button matSuffix *ngIf="dataSource.filter" (click)="clearInspectionFilter()" aria-label="Limpar filtro">
-            <mat-icon>close</mat-icon>
-          </button>
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Buscar inspeções</mat-label>
+      <input matInput (keyup)="applyInspectionFilter($event)" placeholder="Status, cliente, cidade..." />
+      <button mat-icon-button matSuffix *ngIf="dataSource.filter" (click)="clearInspectionFilter()" aria-label="Limpar filtro">
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <div class="table-wrapper mat-elevation-z2">
+      <table mat-table [dataSource]="dataSource" matSort>
+        <ng-container matColumnDef="id">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
+          <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
+          <td mat-cell *matCellDef="let row">{{ row.status || '-' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="worder">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Work order</th>
+          <td mat-cell *matCellDef="let row">{{ row.worder || '-' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="client">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Cliente</th>
+          <td mat-cell *matCellDef="let row">{{ row.client || '-' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Nome</th>
+          <td mat-cell *matCellDef="let row">{{ row.name || '-' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="city">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Cidade</th>
+          <td mat-cell *matCellDef="let row">{{ row.city || '-' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="duedate">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Due date</th>
+          <td mat-cell *matCellDef="let row">{{ row.duedate || '-' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Ações</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="actions-cell">
+              <button mat-stroked-button color="primary" (click)="startEditInspection(row)">Editar</button>
+              <button mat-stroked-button color="warn" (click)="deleteInspection(row)">Excluir</button>
+              <button mat-stroked-button (click)="openAssignInspector(row)">Adicionar inspetor</button>
+            </div>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="inspectionColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: inspectionColumns"></tr>
+      </table>
+
+      <mat-paginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25]" aria-label="Paginação"></mat-paginator>
+    </div>
+
+    <div class="editor-box mat-elevation-z2" *ngIf="inspectionEditing">
+      <h3>Edição da inspeção #{{ inspectionEditing.id }}</h3>
+
+      <div class="form-grid">
+        <mat-form-field appearance="outline">
+          <mat-label>Status</mat-label>
+          <input matInput [(ngModel)]="inspectionEditing.status" />
         </mat-form-field>
 
-        <div class="table-wrapper mat-elevation-z2">
-          <table mat-table [dataSource]="dataSource" matSort>
-            <ng-container matColumnDef="id">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
-              <td mat-cell *matCellDef="let row">{{ row.id }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="status">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
-              <td mat-cell *matCellDef="let row">{{ row.status || '-' }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="worder">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header>Work order</th>
-              <td mat-cell *matCellDef="let row">{{ row.worder || '-' }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="client">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header>Cliente</th>
-              <td mat-cell *matCellDef="let row">{{ row.client || '-' }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header>Nome</th>
-              <td mat-cell *matCellDef="let row">{{ row.name || '-' }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="city">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header>Cidade</th>
-              <td mat-cell *matCellDef="let row">{{ row.city || '-' }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="duedate">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header>Due date</th>
-              <td mat-cell *matCellDef="let row">{{ row.duedate || '-' }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef>Ações</th>
-              <td mat-cell *matCellDef="let row" class="actions-cell">
-                <button mat-stroked-button color="primary" (click)="startEditInspection(row)">Editar</button>
-                <button mat-stroked-button color="warn" (click)="deleteInspection(row)">Excluir</button>
-                <button mat-stroked-button (click)="openAssignInspector(row)">Adicionar inspetor</button>
-              </td>
-            </ng-container>
-
-            <tr mat-header-row *matHeaderRowDef="inspectionColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: inspectionColumns"></tr>
-          </table>
-
-          <mat-paginator [pageSize]="10" [pageSizeOptions]="[5, 10, 25]" aria-label="Paginação"></mat-paginator>
-        </div>
-
-        <div class="editor-box mat-elevation-z2" *ngIf="inspectionEditing">
-          <h3>Edição da inspeção #{{ inspectionEditing.id }}</h3>
-
-          <div class="form-grid">
-            <mat-form-field appearance="outline">
-              <mat-label>Status</mat-label>
-              <input matInput [(ngModel)]="inspectionEditing.status" />
-            </mat-form-field>
-
-            <mat-form-field appearance="outline">
-              <mat-label>Cliente</mat-label>
-              <input matInput [(ngModel)]="inspectionEditing.client" />
-            </mat-form-field>
-
-            <mat-form-field appearance="outline">
-              <mat-label>Cidade</mat-label>
-              <input matInput [(ngModel)]="inspectionEditing.city" />
-            </mat-form-field>
-
-            <mat-form-field appearance="outline">
-              <mat-label>Due date</mat-label>
-              <input matInput [(ngModel)]="inspectionEditing.duedate" />
-            </mat-form-field>
-          </div>
-
-          <div class="actions-row">
-            <button mat-raised-button color="primary" (click)="saveInspection()">Salvar edição</button>
-            <button mat-button (click)="cancelEditInspection()">Cancelar</button>
-          </div>
-        </div>
-
-        <div class="editor-box mat-elevation-z2" *ngIf="inspectionForInspectorAssign">
-          <h3>Vincular inspetor na inspeção #{{ inspectionForInspectorAssign.id }}</h3>
-
-          <mat-form-field appearance="outline" class="inspector-select">
-            <mat-label>Inspetor</mat-label>
-            <mat-select [(value)]="selectedInspectorId">
-              <mat-option *ngFor="let inspector of inspectorsDataSource.data" [value]="inspector.id">
-                {{ inspector.nome }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-
-          <div class="actions-row">
-            <button mat-raised-button color="accent" (click)="assignInspector()">Adicionar inspetor</button>
-          </div>
-        </div>
-      </div>
-    </mat-tab>
-
-    <mat-tab label="Cadastro de inspetor">
-      <div class="tab-content">
-        <div class="editor-box mat-elevation-z2">
-          <h3>{{ inspectorForm.id ? 'Editar inspetor' : 'Novo inspetor' }}</h3>
-
-          <div class="form-grid one-column">
-            <mat-form-field appearance="outline">
-              <mat-label>Nome do inspetor</mat-label>
-              <input matInput [(ngModel)]="inspectorForm.nome" />
-            </mat-form-field>
-          </div>
-
-          <div class="actions-row">
-            <button mat-raised-button color="primary" (click)="saveInspector()">
-              {{ inspectorForm.id ? 'Salvar alteração' : 'Cadastrar' }}
-            </button>
-            <button mat-button *ngIf="inspectorForm.id" (click)="cancelInspectorEdit()">Cancelar</button>
-          </div>
-        </div>
-
-        <mat-form-field appearance="outline" class="filter-field">
-          <mat-label>Buscar inspetor</mat-label>
-          <input matInput (keyup)="applyInspectorFilter($event)" placeholder="Digite o nome" />
+        <mat-form-field appearance="outline">
+          <mat-label>Cliente</mat-label>
+          <input matInput [(ngModel)]="inspectionEditing.client" />
         </mat-form-field>
 
-        <div class="table-wrapper mat-elevation-z2">
-          <table mat-table [dataSource]="inspectorsDataSource">
-            <ng-container matColumnDef="id">
-              <th mat-header-cell *matHeaderCellDef>ID</th>
-              <td mat-cell *matCellDef="let row">{{ row.id }}</td>
-            </ng-container>
+        <mat-form-field appearance="outline">
+          <mat-label>Cidade</mat-label>
+          <input matInput [(ngModel)]="inspectionEditing.city" />
+        </mat-form-field>
 
-            <ng-container matColumnDef="nome">
-              <th mat-header-cell *matHeaderCellDef>Nome</th>
-              <td mat-cell *matCellDef="let row">{{ row.nome }}</td>
-            </ng-container>
-
-            <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef>Ações</th>
-              <td mat-cell *matCellDef="let row" class="actions-cell">
-                <button mat-stroked-button color="primary" (click)="editInspector(row)">Editar</button>
-                <button mat-stroked-button color="warn" (click)="deleteInspector(row)">Excluir</button>
-              </td>
-            </ng-container>
-
-            <tr mat-header-row *matHeaderRowDef="inspectorColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: inspectorColumns"></tr>
-          </table>
-        </div>
+        <mat-form-field appearance="outline">
+          <mat-label>Due date</mat-label>
+          <input matInput [(ngModel)]="inspectionEditing.duedate" />
+        </mat-form-field>
       </div>
-    </mat-tab>
-  </mat-tab-group>
+
+      <div class="actions-row">
+        <button mat-raised-button color="primary" (click)="saveInspection()">Salvar edição</button>
+        <button mat-button (click)="cancelEditInspection()">Cancelar</button>
+      </div>
+    </div>
+
+    <div class="editor-box mat-elevation-z2" *ngIf="inspectionForInspectorAssign">
+      <h3>Vincular inspetor na inspeção #{{ inspectionForInspectorAssign.id }}</h3>
+
+      <mat-form-field appearance="outline" class="inspector-select">
+        <mat-label>Inspetor</mat-label>
+        <mat-select [(value)]="selectedInspectorId">
+          <mat-option *ngFor="let inspector of inspectorsDataSource.data" [value]="inspector.id">
+            {{ inspector.nome }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <div class="actions-row">
+        <button mat-raised-button color="accent" (click)="assignInspector()">Adicionar inspetor</button>
+      </div>
+    </div>
+  </div>
+
+  <div *ngIf="viewMode === 'inspectors'" class="page-content">
+    <div class="editor-box mat-elevation-z2">
+      <h3>{{ inspectorForm.id ? 'Editar inspetor' : 'Novo inspetor' }}</h3>
+
+      <div class="form-grid one-column">
+        <mat-form-field appearance="outline">
+          <mat-label>Nome do inspetor</mat-label>
+          <input matInput [(ngModel)]="inspectorForm.nome" />
+        </mat-form-field>
+      </div>
+
+      <div class="actions-row">
+        <button mat-raised-button color="primary" (click)="saveInspector()">
+          {{ inspectorForm.id ? 'Salvar alteração' : 'Cadastrar' }}
+        </button>
+        <button mat-button *ngIf="inspectorForm.id" (click)="cancelInspectorEdit()">Cancelar</button>
+      </div>
+    </div>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Buscar inspetor</mat-label>
+      <input matInput (keyup)="applyInspectorFilter($event)" placeholder="Digite o nome" />
+    </mat-form-field>
+
+    <div class="table-wrapper mat-elevation-z2">
+      <table mat-table [dataSource]="inspectorsDataSource">
+        <ng-container matColumnDef="id">
+          <th mat-header-cell *matHeaderCellDef>ID</th>
+          <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="nome">
+          <th mat-header-cell *matHeaderCellDef>Nome</th>
+          <td mat-cell *matCellDef="let row">{{ row.nome }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Ações</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="actions-cell">
+              <button mat-stroked-button color="primary" (click)="editInspector(row)">Editar</button>
+              <button mat-stroked-button color="warn" (click)="deleteInspector(row)">Excluir</button>
+            </div>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="inspectorColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: inspectorColumns"></tr>
+      </table>
+    </div>
+  </div>
 </section>

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
@@ -2,7 +2,7 @@
   padding: 16px;
 }
 
-.tab-content {
+.page-content {
   padding-top: 12px;
 }
 
@@ -45,6 +45,7 @@ table {
 
 .actions-cell {
   display: flex;
+  align-items: center;
   gap: 8px;
   flex-wrap: wrap;
 }

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
@@ -9,9 +9,9 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatSelectModule } from '@angular/material/select';
 import { finalize } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 
 import { Inspection } from '../../../models/inspection.model';
 import { Inspector } from '../../../models/inspector.model';
@@ -31,13 +31,13 @@ import { InspectionService } from '../inspection.service';
     MatButtonModule,
     MatIconModule,
     MatSnackBarModule,
-    MatTabsModule,
     MatSelectModule
   ],
   templateUrl: './inspection-import-list.component.html',
   styleUrl: './inspection-import-list.component.scss'
 })
 export class InspectionImportListComponent implements AfterViewInit {
+  viewMode: 'inspections' | 'inspectors' = 'inspections';
   inspectionColumns: string[] = ['id', 'status', 'worder', 'client', 'name', 'city', 'duedate', 'actions'];
   inspectorColumns: string[] = ['id', 'nome', 'actions'];
 
@@ -59,8 +59,14 @@ export class InspectionImportListComponent implements AfterViewInit {
 
   constructor(
     private inspectionService: InspectionService,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private route: ActivatedRoute
   ) {
+    const routeView = this.route.snapshot.data['view'];
+    if (routeView === 'inspectors') {
+      this.viewMode = 'inspectors';
+    }
+
     this.dataSource.filterPredicate = (data: Inspection, filter: string) => {
       const search = filter.trim().toLowerCase();
       return [data.status, data.worder, data.client, data.name, data.city, data.duedate, data.inspector]
@@ -75,7 +81,10 @@ export class InspectionImportListComponent implements AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.loadInspections();
+    if (this.viewMode === 'inspections') {
+      this.loadInspections();
+    }
+
     this.loadInspectors();
   }
 

--- a/src/app/components/template/nav/nav.component.ts
+++ b/src/app/components/template/nav/nav.component.ts
@@ -38,6 +38,7 @@ export class NavComponent {
     { label: 'Criar lead', icon: 'note_add', route: 'lead/completo', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Documentos', icon: 'upload', route: '/leads/documento', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Inspeções', icon: 'fact_check', route: '/inspections', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
+    { label: 'Cadastro de inspetor', icon: 'badge', route: '/inspectors', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Endereco Lead', icon: 'create', route: '/endreco', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Usuários', icon: 'people', route: '/users', roles: ['ROLE_ADMIN'] },
     { label: 'Cadastrar Usuário', icon: 'person_add', route: '/register', roles: ['ROLE_ADMIN'] }  ];


### PR DESCRIPTION
### Motivation
- Separar o fluxo de "Inspeções" e o formulário de "Cadastro de inspetor" para que o cadastro fique acessível via menu próprio em vez de estar junto às inspeções em abas. 
- Corrigir o desalinhamento dos botões da coluna "Ações" nas tabelas para ter apresentação consistente entre linhas.

### Description
- Adiciona `viewMode` no componente `InspectionImportListComponent` e usa `ActivatedRoute` + `route.data.view` para renderizar condicionalmente a visualização de `inspections` ou `inspectors` sem alterar a lógica de negócio existente. (`src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts`).
- Substitui as abas por renderização condicional no template, movendo os blocos de inspeções e de cadastro de inspetor para seções separadas no mesmo componente e envolvendo os botões de ação em um `div.actions-cell` dentro do `td` para corrigir alinhamento. (`src/app/components/inspection/inspection-import-list/inspection-import-list.component.html`).
- Atualiza estilos para usar `.page-content` e ajusta `.actions-cell` com `align-items: center` para alinhar verticalmente os botões. (`src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss`).
- Cria nova rota `/inspectors` que reusa `InspectionImportListComponent` com `data: { view: 'inspectors' }` e adiciona item de menu "Cadastro de inspetor" no `NavComponent`. (`src/app/app.routes.ts`, `src/app/components/template/nav/nav.component.ts`).

### Testing
- Executado `npx ng build --configuration development` e a build de desenvolvimento completou com sucesso. ✅
- Executado `npm run build` que falhou na etapa de inlining de fontes por uma limitação de ambiente externa (Google Fonts retornou 403), sem relação com as alterações de template/CSS. ⚠️
- Servidor de desenvolvimento iniciado com `npm run start` e navegação para `/inspections` e `/inspectors` foi verificada; capturas de tela foram geradas automaticamente para ambas as páginas via script de teste. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d3ced3864832295293ccdf941ff93)