### PR TITLE
Centraliza URL da API e refatora serviços para integrar front-end ao back-end

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -56,7 +56,13 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -2,25 +2,30 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { BehaviorSubject, tap } from 'rxjs';
-import {PermissionModel} from '../../models/Permission.model';
+import { PermissionModel } from '../../models/Permission.model';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
+  private readonly apiBaseUrl = environment.apiBaseUrl;
+  private readonly authApiUrl = `${this.apiBaseUrl}/auth`;
+  private readonly usersApiUrl = `${this.apiBaseUrl}/api/users`;
+  private readonly permissionsApiUrl = `${this.apiBaseUrl}/api/permissions`;
+
   private jwtSubject = new BehaviorSubject<string | null>(this.getToken());
   jwt$ = this.jwtSubject.asObservable();
 
   constructor(private http: HttpClient, private router: Router) {}
 
   login(credentials: { username: string; password: string }) {
-    return this.http.post<{ token: string }>(
-      'http://localhost:8080/auth/login',
-      credentials
-    ).pipe(
-      tap(res => {
-        this.setToken(res.token);
-        this.jwtSubject.next(res.token);
-      })
-    );
+    return this.http
+      .post<{ token: string }>(`${this.authApiUrl}/login`, credentials)
+      .pipe(
+        tap((res) => {
+          this.setToken(res.token);
+          this.jwtSubject.next(res.token);
+        })
+      );
   }
 
   logout() {
@@ -35,28 +40,33 @@ export class AuthService {
     email: string;
     telefone: string;
     password: string;
-    permissions: PermissionModel[]
+    permissions: PermissionModel[];
   }) {
-    return this.http.post(
-      'http://localhost:8080/api/users',
-      user
-    );
-  }
-  getPermissions() {
-    return this.http.get<PermissionModel[]>(
-      'http://localhost:8080/api/permissions'
-    );
+    return this.http.post(this.usersApiUrl, user);
   }
 
-  // Protege acesso ao localStorage com try/catch
+  getPermissions() {
+    return this.http.get<PermissionModel[]>(this.permissionsApiUrl);
+  }
+
   private setToken(token: string) {
-    try { localStorage.setItem('jwt', token); } catch {}
+    try {
+      localStorage.setItem('jwt', token);
+    } catch {}
   }
+
   getToken(): string | null {
-    try { return localStorage.getItem('jwt'); } catch { return null; }
+    try {
+      return localStorage.getItem('jwt');
+    } catch {
+      return null;
+    }
   }
+
   private removeToken() {
-    try { localStorage.removeItem('jwt'); } catch {}
+    try {
+      localStorage.removeItem('jwt');
+    } catch {}
   }
 
   get token() {
@@ -67,21 +77,20 @@ export class AuthService {
     return !!this.getToken();
   }
 
-  // Método para verificar se possui pelo menos uma das roles
   hasAnyRole(roles: string[]): boolean {
     const token = this.token;
     if (!token) return false;
     try {
       const payload = JSON.parse(atob(token.split('.')[1]));
       const userRoles: string[] = payload.roles || payload.authorities || [];
-      return roles.some(role => userRoles.includes(role));
+      return roles.some((role) => userRoles.includes(role));
     } catch {
       return false;
     }
   }
 
   getRoles(): string[] {
-    const token = localStorage.getItem('jwt'); // <-- troque de 'token' para 'jwt'
+    const token = localStorage.getItem('jwt');
     if (!token) return [];
     try {
       const payload = JSON.parse(atob(token.split('.')[1]));
@@ -94,6 +103,4 @@ export class AuthService {
   hasRole(role: string): boolean {
     return this.getRoles().includes(role);
   }
-
-
 }

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -3,13 +3,14 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Inspection } from '../../models/inspection.model';
 import { Inspector } from '../../models/inspector.model';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class InspectionService {
-  private readonly inspectionsApiUrl = 'http://localhost:8080/api/inspections';
-  private readonly inspectorsApiUrl = 'http://localhost:8080/api/inspetores';
+  private readonly inspectionsApiUrl = `${environment.apiBaseUrl}/api/inspections`;
+  private readonly inspectorsApiUrl = `${environment.apiBaseUrl}/api/inspetores`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/components/lead/lead.service.ts
+++ b/src/app/components/lead/lead.service.ts
@@ -1,93 +1,98 @@
-import { validateHorizontalPosition } from '@angular/cdk/overlay';
 import { Injectable } from '@angular/core';
-import {
-  MatSnackBar,
-  MatSnackBarAction,
-  MatSnackBarActions,
-  MatSnackBarLabel,
-  MatSnackBarRef,
-} from '@angular/material/snack-bar';
-import { LeadCreateComponent } from './lead-create/lead-create.component';
-import {HttpClient, HttpHeaders} from '@angular/common/http';
-import { Lead } from '../../models/lead.model';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import {DocumentoLead} from '../../models/documentoLead.model';
-import {Endereco} from '../../models/endereco.model';
-import {LeadCadastroCompletoDTO} from '../../models/dto/leadCadastroCompletoDTO';
+import { Lead } from '../../models/lead.model';
+import { DocumentoLead } from '../../models/documentoLead.model';
+import { Endereco } from '../../models/endereco.model';
+import { LeadCadastroCompletoDTO } from '../../models/dto/leadCadastroCompletoDTO';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LeadService {
+  private readonly apiBaseUrl = environment.apiBaseUrl;
+  private readonly leadsApiUrl = `${this.apiBaseUrl}/api/leads`;
+  private readonly correspondentesApiUrl = `${this.apiBaseUrl}/api/correspondente/leads/completos`;
+  private readonly usersApiUrl = `${this.apiBaseUrl}/api/users`;
+  private readonly documentosLeadApiUrl = `${this.apiBaseUrl}/api/documentos-lead`;
+  private readonly enderecosLeadApiUrl = `${this.apiBaseUrl}/api/enderecos-lead`;
 
+  constructor(
+    private snackBar: MatSnackBar,
+    private http: HttpClient
+  ) {}
 
-  baseUrl = "http://localhost:8080/leads";
-  private apiUrl = "http://localhost:8080/api/leads";
-  private apiCorresp = "http://localhost:8080/api/correspondente/leads/completos";
-  constructor(private snackBar: MatSnackBar, private http: HttpClient) { }
-
-  showOnConsole(msg: string): void{
-    this.snackBar.open(msg , '',{
-      duration:3000,
-      horizontalPosition: "right",
-      verticalPosition: "top"
-    })
-
+  showOnConsole(msg: string): void {
+    this.snackBar.open(msg, '', {
+      duration: 3000,
+      horizontalPosition: 'right',
+      verticalPosition: 'top'
+    });
   }
 
   read(): Observable<Lead[]> {
-    return this.http.get<Lead[]>(this.apiUrl);
+    return this.http.get<Lead[]>(this.leadsApiUrl);
   }
+
   listCorrespondent(): Observable<Lead[]> {
-    return this.http.get<Lead[]>(this.apiCorresp);
+    return this.http.get<Lead[]>(this.correspondentesApiUrl);
   }
 
   create(lead: Lead): Observable<Lead> {
-    return this.http.post<Lead>(this.apiUrl, lead);
+    return this.http.post<Lead>(this.leadsApiUrl, lead);
   }
 
   update(lead: Lead): Observable<Lead> {
-    return this.http.put<Lead>(`${this.apiUrl}/${lead.id}`, lead);
+    return this.http.put<Lead>(`${this.leadsApiUrl}/${lead.id}`, lead);
   }
-  listCorretores(): Observable<{ id: number, nome: string }[]> {
-    return this.http.get<{ id: number, nome: string }[]>('http://localhost:8080/api/users/corretores');
+
+  listCorretores(): Observable<{ id: number; nome: string }[]> {
+    return this.http.get<{ id: number; nome: string }[]>(`${this.usersApiUrl}/corretores`);
   }
 
   uploadDocumentos(formData: FormData) {
-    return this.http.post('http://localhost:8080/api/documentos-lead/upload', formData)
+    return this.http.post(`${this.documentosLeadApiUrl}/upload`, formData);
   }
+
   getDocumentosDoLead(leadId: number) {
-    return this.http.get<DocumentoLead[]>(`http://localhost:8080/api/documentos-lead/lead/${leadId}`);
+    return this.http.get<DocumentoLead[]>(`${this.documentosLeadApiUrl}/lead/${leadId}`);
   }
 
   downloadDocumento(id: number) {
-    return this.http.get(`http://localhost:8080/api/documentos-lead/${id}/download`, { responseType: 'blob' });
+    return this.http.get(`${this.documentosLeadApiUrl}/${id}/download`, { responseType: 'blob' });
   }
 
   deletarDocumento(documentoId: number) {
-    return this.http.delete(`http://localhost:8080/api/documentos-lead/${documentoId}`);
-  }
-  listarEnderecosDoLead(leadId?: number): Observable<Endereco[]> {
-    return this.http.get<Endereco[]>(`http://localhost:8080/api/enderecos-lead/lead/${leadId}`);
-  }
-  adicionarEndereco(endereco: Endereco): Observable<Endereco> {
-    return this.http.post<Endereco>(`http://localhost:8080/api/enderecos-lead`, endereco);
-  }
-  updateEndereco( endereco: Endereco) {
-    return this.http.put<Endereco>(`http://localhost:8080/api/enderecos-lead`, endereco);
+    return this.http.delete(`${this.documentosLeadApiUrl}/${documentoId}`);
   }
 
-    deleteEndereco( enderecoId: number) {
-      return this.http.delete(`http://localhost:8080/api/enderecos-lead/${enderecoId}`);
-    }
+  listarEnderecosDoLead(leadId?: number): Observable<Endereco[]> {
+    return this.http.get<Endereco[]>(`${this.enderecosLeadApiUrl}/lead/${leadId}`);
+  }
+
+  adicionarEndereco(endereco: Endereco): Observable<Endereco> {
+    return this.http.post<Endereco>(this.enderecosLeadApiUrl, endereco);
+  }
+
+  updateEndereco(endereco: Endereco) {
+    return this.http.put<Endereco>(this.enderecosLeadApiUrl, endereco);
+  }
+
+  deleteEndereco(enderecoId: number) {
+    return this.http.delete(`${this.enderecosLeadApiUrl}/${enderecoId}`);
+  }
+
   definirEnderecoPrincipal(leadId: number, enderecoId: number) {
-    return this.http.put(`http://localhost:8080/api/enderecos-lead/${leadId}/definir-principal/${enderecoId}`, null);
+    return this.http.put(`${this.enderecosLeadApiUrl}/${leadId}/definir-principal/${enderecoId}`, null);
   }
 
   cadastrarCompleto(dto: LeadCadastroCompletoDTO) {
-    return this.http.post(`http://localhost:8080/api/leads/cadastro-completo`, dto);
+    return this.http.post(`${this.leadsApiUrl}/cadastro-completo`, dto);
   }
+
   solicitarDocumentos(leadId: number) {
-    return this.http.post<{link: string}>(`http://localhost:8080/api/leads/${leadId}/solicitar-documentos`, {});
+    return this.http.post<{ link: string }>(`${this.leadsApiUrl}/${leadId}/solicitar-documentos`, {});
   }
 }

--- a/src/app/components/user/user.service.ts
+++ b/src/app/components/user/user.service.ts
@@ -2,12 +2,13 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Usuario } from '../../models/usuario.model';
+import { environment } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserService {
-  private apiUrl = 'http://localhost:8080/api/users';
+  private readonly apiUrl = `${environment.apiBaseUrl}/api/users`;
 
   constructor(private http: HttpClient) {}
 
@@ -19,7 +20,7 @@ export class UserService {
     return this.http.get<Usuario>(`${this.apiUrl}/${id}`);
   }
 
-  update(id: number, user: any): Observable<Usuario> {
+  update(id: number, user: unknown): Observable<Usuario> {
     return this.http.put<Usuario>(`${this.apiUrl}/${id}`, user);
   }
 }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:8080'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: 'http://localhost:8080'
+};


### PR DESCRIPTION
### Motivation
- Centralizar a URL base do backend para facilitar a integração entre front-end e back-end e suportar múltiplos ambientes.
- Evitar múltiplos endpoints hardcoded espalhados pelo projeto e reduzir chances de inconsistência ao mudar de ambiente.

### Description
- Adiciona arquivos de ambiente `src/environments/environment.ts` e `src/environments/environment.development.ts` com a propriedade `apiBaseUrl` para configurar a URL do backend por ambiente.
- Atualiza `AuthService` para montar endpoints (`/auth`, `/api/users`, `/api/permissions`) a partir de `environment.apiBaseUrl` em vez de URLs hardcoded.
- Refatora `LeadService`, `UserService` e `InspectionService` para usar `environment.apiBaseUrl` e centralizar todas as chamadas `http` para os endpoints (`/api/leads`, `/api/documentos-lead`, `/api/enderecos-lead`, `/api/inspections`, etc.).
- Ajusta `angular.json` para aplicar `fileReplacements` e usar `environment.development.ts` na build de desenvolvimento.

### Testing
- `npm run build -- --configuration development` foi executado com sucesso e gerou o bundle em `dist/crm-security-front` (✅).
- `npm run build` (produção) falhou por um problema externo ao ambiente ao tentar inline de fontes do Google (`HTTP 403`) durante a build (⚠️).
- `npm run test -- --watch=false --browsers=ChromeHeadless` falhou devido a specs que importam símbolos inexistentes (ex.: `authGuard` e `JwtService`) que já estavam quebrando os testes no repositório (❌).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d41fd4938832284e7a1808925bd2b)