### PR TITLE
Integrate Angular app with Spring Security backend via dev proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Sistema CRM desenvolvido para otimizar processos de captação, gestão e acompa
 
 ---
 
+
+## 🔗 Integração Angular + Spring Security (Java)
+
+Para rodar frontend e backend juntos em ambiente local sem erro de CORS:
+
+1. Suba o backend Spring Security em `http://localhost:8080`.
+2. Suba o frontend Angular com `npm start` (ou `ng serve`).
+3. O Angular usa `proxy.conf.json` para redirecionar automaticamente chamadas `/auth` e `/api` para o backend Java.
+
+Isso permite manter chamadas HTTP relativas no frontend (ex.: `/auth/login`, `/api/users`) e simplifica a integração entre os dois projetos.
+
+---
 ## 🏗️ Tecnologias Utilizadas
 
 ### Backend

--- a/angular.json
+++ b/angular.json
@@ -77,7 +77,10 @@
               "buildTarget": "crm-security-front:build:development"
             }
           },
-          "defaultConfiguration": "development"
+          "defaultConfiguration": "development",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n"

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,14 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  },
+  "/auth": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8080'
+  apiBaseUrl: ''
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'http://localhost:8080'
+  apiBaseUrl: ''
 };


### PR DESCRIPTION
### Motivation
- Permitir execução local do frontend Angular em conjunto com o backend Java (Spring Security) sem problemas de CORS usando um proxy de desenvolvimento.
- Evitar hardcode da URL do backend no frontend para que chamadas relativas funcionem tanto em dev quanto em prod.

### Description
- Adicionado `proxy.conf.json` para redirecionar `/api` e `/auth` para `http://localhost:8080` durante o desenvolvimento.
- Atualizado `angular.json` para definir `serve.options.proxyConfig` apontando para `proxy.conf.json` no modo `ng serve`.
- Alterados `src/environments/environment.ts` e `src/environments/environment.development.ts` para usar `apiBaseUrl: ''` (URL relativa) para trabalhar com o proxy/local same-origin.
- Documentado o fluxo de integração no `README.md` explicando como rodar frontend e backend juntos e qual o papel do `proxy.conf.json`.

### Testing
- Executei `npm run build`, que falhou por erro de ambiente externo (a inlining de fontes do Google retornou HTTP 403), então a build não pôde ser concluída aqui.
- Executei `npm run test -- --watch=false --browsers=ChromeHeadless`, que falhou por erros de testes pré-existentes não relacionados a este PR (import/export inconsistentes em specs: `authGuard`/`JwtService`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d45a518bc832293db790bbf2418bc)