### PR TITLE
feat: adicionar Upload de inspeção (ZIP) na navbar

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -90,5 +90,11 @@ export const routes: Routes = [
     component: InspectionImportListComponent,
     canActivate: [AuthGuard],
     data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], view: 'photos-inspections' }
+  },
+  {
+    path: 'inspection-upload',
+    component: InspectionImportListComponent,
+    canActivate: [AuthGuard],
+    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], view: 'inspection-upload' }
   }
 ];

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
@@ -2,6 +2,7 @@
   <h2 *ngIf="viewMode === 'inspections'">Gestão de inspeções</h2>
   <h2 *ngIf="viewMode === 'inspectors'">Cadastro de inspetor</h2>
   <h2 *ngIf="viewMode === 'photos-inspections'">Fotos de inspeções</h2>
+  <h2 *ngIf="viewMode === 'inspection-upload'">Upload de inspeção</h2>
 
   <div *ngIf="viewMode === 'inspections'" class="page-content">
     <div class="import-box mat-elevation-z2">
@@ -215,6 +216,67 @@
 
         <tr mat-header-row *matHeaderRowDef="photosInspectionColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: photosInspectionColumns"></tr>
+      </table>
+    </div>
+  </div>
+
+  <div *ngIf="viewMode === 'inspection-upload'" class="page-content">
+    <div class="import-box mat-elevation-z2">
+      <input type="file" accept=".zip" (change)="onZipSelected($event)" />
+
+      <button mat-raised-button color="primary" (click)="uploadInspectionZip()" [disabled]="isLoading">
+        <mat-icon>folder_zip</mat-icon>
+        Enviar ZIP
+      </button>
+
+      <span class="file-name" *ngIf="selectedZipFile">{{ selectedZipFile.name }}</span>
+    </div>
+
+    <div *ngIf="uploadResult" class="editor-box mat-elevation-z2">
+      <h3>Resumo do processamento</h3>
+      <p><strong>Total de arquivos:</strong> {{ uploadResult.totalArquivos }}</p>
+      <p><strong>Processadas:</strong> {{ uploadResult.processadas }}</p>
+      <p><strong>Não processadas:</strong> {{ uploadResult.naoProcessadas }}</p>
+    </div>
+
+    <div *ngIf="uploadResult" class="table-wrapper mat-elevation-z2 upload-table">
+      <h3>Fotos processadas</h3>
+      <table mat-table [dataSource]="processedPhotosDataSource">
+        <ng-container matColumnDef="arquivo">
+          <th mat-header-cell *matHeaderCellDef>Arquivo</th>
+          <td mat-cell *matCellDef="let row">{{ row.arquivo }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="inspectionId">
+          <th mat-header-cell *matHeaderCellDef>Inspection ID</th>
+          <td mat-cell *matCellDef="let row">{{ row.inspectionId }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="substituida">
+          <th mat-header-cell *matHeaderCellDef>Substituída</th>
+          <td mat-cell *matCellDef="let row">{{ row.substituida ? 'Sim' : 'Não' }}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="processedPhotosColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: processedPhotosColumns"></tr>
+      </table>
+    </div>
+
+    <div *ngIf="uploadResult" class="table-wrapper mat-elevation-z2 upload-table">
+      <h3>Fotos não processadas</h3>
+      <table mat-table [dataSource]="unprocessedPhotosDataSource">
+        <ng-container matColumnDef="arquivo">
+          <th mat-header-cell *matHeaderCellDef>Arquivo</th>
+          <td mat-cell *matCellDef="let row">{{ row.arquivo }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="motivo">
+          <th mat-header-cell *matHeaderCellDef>Motivo</th>
+          <td mat-cell *matCellDef="let row">{{ row.motivo }}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="unprocessedPhotosColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: unprocessedPhotosColumns"></tr>
       </table>
     </div>
   </div>

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
@@ -69,3 +69,16 @@ table {
 .inspector-select {
   width: min(420px, 100%);
 }
+
+.upload-table {
+  margin-top: 16px;
+  padding: 12px;
+}
+
+.upload-table h3 {
+  margin: 0 0 10px;
+}
+
+.upload-table table {
+  min-width: 680px;
+}

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
@@ -17,6 +17,11 @@ import { ActivatedRoute } from '@angular/router';
 import { Inspection } from '../../../models/inspection.model';
 import { Inspector } from '../../../models/inspector.model';
 import { PhotoInspection } from '../../../models/photo-inspection.model';
+import {
+  FotoNaoProcessada,
+  FotoProcessada,
+  InspectionZipUploadResponse
+} from '../../../models/inspection-zip-upload-response.model';
 import { InspectionService } from '../inspection.service';
 import { AuthService } from '../../../auth/services/auth.service';
 
@@ -40,7 +45,7 @@ import { AuthService } from '../../../auth/services/auth.service';
   styleUrl: './inspection-import-list.component.scss'
 })
 export class InspectionImportListComponent implements AfterViewInit {
-  viewMode: 'inspections' | 'inspectors' | 'photos-inspections' = 'inspections';
+  viewMode: 'inspections' | 'inspectors' | 'photos-inspections' | 'inspection-upload' = 'inspections';
   readonly canManageInspectors: boolean;
   inspectionColumns: string[] = ['id', 'status', 'worder', 'client', 'name', 'city', 'duedate', 'actions'];
   inspectorColumns: string[] = ['id', 'nome', 'actions'];
@@ -51,8 +56,14 @@ export class InspectionImportListComponent implements AfterViewInit {
   photosInspectionsDataSource = new MatTableDataSource<PhotoInspection>([]);
 
   selectedFile?: File;
+  selectedZipFile?: File;
   isLoading = false;
   selectedInspectorId?: number;
+  uploadResult?: InspectionZipUploadResponse;
+  processedPhotosDataSource = new MatTableDataSource<FotoProcessada>([]);
+  unprocessedPhotosDataSource = new MatTableDataSource<FotoNaoProcessada>([]);
+  processedPhotosColumns: string[] = ['arquivo', 'inspectionId', 'substituida'];
+  unprocessedPhotosColumns: string[] = ['arquivo', 'motivo'];
 
   inspectionEditing?: Inspection;
   inspectionForInspectorAssign?: Inspection;
@@ -78,6 +89,10 @@ export class InspectionImportListComponent implements AfterViewInit {
 
     if (routeView === 'photos-inspections') {
       this.viewMode = 'photos-inspections';
+    }
+
+    if (routeView === 'inspection-upload') {
+      this.viewMode = 'inspection-upload';
     }
 
     this.dataSource.filterPredicate = (data: Inspection, filter: string) => {
@@ -112,6 +127,10 @@ export class InspectionImportListComponent implements AfterViewInit {
       return;
     }
 
+    if (this.viewMode === 'inspection-upload') {
+      return;
+    }
+
     this.loadPhotosInspections();
   }
 
@@ -137,6 +156,33 @@ export class InspectionImportListComponent implements AfterViewInit {
           this.loadInspections();
         },
         error: () => this.showMessage('Falha ao importar arquivo. Verifique o layout e tente novamente.')
+      });
+  }
+
+  onZipSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedZipFile = input.files?.[0];
+  }
+
+  uploadInspectionZip(): void {
+    if (!this.selectedZipFile) {
+      this.showMessage('Selecione um arquivo .zip para upload.');
+      return;
+    }
+
+    this.isLoading = true;
+    this.inspectionService
+      .uploadInspectionZip(this.selectedZipFile)
+      .pipe(finalize(() => (this.isLoading = false)))
+      .subscribe({
+        next: (response) => {
+          this.uploadResult = response;
+          this.processedPhotosDataSource.data = response.fotosProcessadas || [];
+          this.unprocessedPhotosDataSource.data = response.fotosNaoProcessadas || [];
+          this.showMessage('Upload da inspeção concluído com sucesso.');
+          this.selectedZipFile = undefined;
+        },
+        error: () => this.showMessage('Falha ao enviar ZIP. Verifique o arquivo e tente novamente.')
       });
   }
 

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -4,6 +4,7 @@ import { catchError, Observable, throwError } from 'rxjs';
 import { Inspection } from '../../models/inspection.model';
 import { Inspector } from '../../models/inspector.model';
 import { PhotoInspection } from '../../models/photo-inspection.model';
+import { InspectionZipUploadResponse } from '../../models/inspection-zip-upload-response.model';
 import { environment } from '../../../environments/environment';
 
 @Injectable({
@@ -57,6 +58,12 @@ export class InspectionService {
 
   listPhotosInspections(): Observable<PhotoInspection[]> {
     return this.http.get<PhotoInspection[]>(this.photosInspectionsApiUrl);
+  }
+
+  uploadInspectionZip(file: File): Observable<InspectionZipUploadResponse> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post<InspectionZipUploadResponse>(`${this.photosInspectionsApiUrl}/import`, formData);
   }
 
   private inspectorRequestWithFallback<T>(request: (baseUrl: string) => Observable<T>): Observable<T> {

--- a/src/app/components/template/nav/nav.component.ts
+++ b/src/app/components/template/nav/nav.component.ts
@@ -36,6 +36,7 @@ export class NavComponent {
     { label: 'Inspeções', icon: 'fact_check', route: '/inspections', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Cadastro de inspetor', icon: 'badge', route: '/inspectors', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Fotos de inspeções', icon: 'photo_library', route: '/photos-inspections', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
+    { label: 'Upload de inspeção', icon: 'folder_zip', route: '/inspection-upload', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Usuários', icon: 'people', route: '/users', roles: ['ROLE_ADMIN'] },
     { label: 'Cadastrar Usuário', icon: 'person_add', route: '/register', roles: ['ROLE_ADMIN'] }  ];
 

--- a/src/app/models/inspection-zip-upload-response.model.ts
+++ b/src/app/models/inspection-zip-upload-response.model.ts
@@ -1,0 +1,18 @@
+export interface FotoProcessada {
+  arquivo: string;
+  inspectionId: number;
+  substituida: boolean;
+}
+
+export interface FotoNaoProcessada {
+  arquivo: string;
+  motivo: string;
+}
+
+export interface InspectionZipUploadResponse {
+  totalArquivos: number;
+  processadas: number;
+  naoProcessadas: number;
+  fotosProcessadas: FotoProcessada[];
+  fotosNaoProcessadas: FotoNaoProcessada[];
+}


### PR DESCRIPTION
### Motivation
- Adicionar na navbar um item "Upload de inspeção" que permita enviar um ZIP com fotos para o backend e exibir o resultado do processamento.
- Reutilizar a mesma API/serviço já usado para fotos de inspeções para manter consistência com os outros fluxos de inspeção.

### Description
- Adicionado item de menu `Upload de inspeção` em `src/app/components/template/nav/nav.component.ts` apontando para a rota `/inspection-upload`.
- Registrada a nova rota `inspection-upload` em `src/app/app.routes.ts` que reutiliza `InspectionImportListComponent` com `data.view = 'inspection-upload'`.
- Estendido `InspectionImportListComponent` (`src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts`) com novo `viewMode` `inspection-upload`, input para `.zip`, métodos `onZipSelected` e `uploadInspectionZip`, e bindings para exibir `uploadResult` com tabelas de fotos processadas e não processadas.
- Criado o modelo tipado `InspectionZipUploadResponse` (e tipos `FotoProcessada` / `FotoNaoProcessada`) em `src/app/models/inspection-zip-upload-response.model.ts` para mapear o retorno do backend.
- Incluído `uploadInspectionZip` em `InspectionService` (`src/app/components/inspection/inspection.service.ts`) que envia `FormData` para o endpoint `${photosInspectionsApiUrl}/import` (`/api/fotosinspections/import`).
- Ajustadas views e estilos em `inspection-import-list.component.html` e `.scss` para suportar o novo fluxo e as tabelas de resultado.

### Testing
- Executei `npm run build`, que falhou devido a limitação do ambiente (`Inlining of fonts failed` ao acessar Google Fonts com status 403), portanto o build não concluiu com sucesso.
- Não houve execução de outros testes automáticos (unit/integration) neste ambiente após as alterações devido ao erro de build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda7354a508322b38bfa3f49d6bf36)