### PR TITLE
Fix photo-inspections API path and ZIP upload endpoint

### DIFF
--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -14,7 +14,7 @@ export class InspectionService {
   private readonly inspectionsApiUrl = `${environment.apiBaseUrl}/api/inspections`;
   private readonly inspectorsApiUrl = `${environment.apiBaseUrl}/api/inspetores`;
   private readonly inspectorsApiUrlFallback = `${environment.apiBaseUrl}/api/inspectors`;
-  private readonly photosInspectionsApiUrl = `${environment.apiBaseUrl}/api/fotosinspections`;
+  private readonly photosInspectionsApiUrl = `${environment.apiBaseUrl}/api/foto-inspections`;
   private readonly photoInspectionsImportApiUrl = `${environment.apiBaseUrl}/api/foto-inspections/import-zip`;
 
   constructor(private http: HttpClient) {}
@@ -65,7 +65,6 @@ export class InspectionService {
     const formData = new FormData();
     formData.append('file', file);
     return this.http.post<InspectionZipUploadResponse>(this.photoInspectionsImportApiUrl, formData);
-    return this.http.post<InspectionZipUploadResponse>(`${this.photosInspectionsApiUrl}/import`, formData);
   }
 
   private inspectorRequestWithFallback<T>(request: (baseUrl: string) => Observable<T>): Observable<T> {


### PR DESCRIPTION
### Motivation
- Align the client API endpoints with backend routes for photo inspections and ensure ZIP uploads are sent to the correct `import-zip` endpoint.

### Description
- Update `photosInspectionsApiUrl` to use `/api/foto-inspections` and add `photoInspectionsImportApiUrl` for `/api/foto-inspections/import-zip`.
- Change `uploadInspectionZip` to post to `photoInspectionsImportApiUrl` instead of `${photosInspectionsApiUrl}/import`.

### Testing
- Ran unit tests with `ng test` and linting with `ng lint`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc7351ad083229d77a6148f6058d0)