### PR TITLE
feat: exibir, filtrar e gerenciar fotos de inspeção

### DIFF
--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
@@ -182,6 +182,28 @@
     </div>
   </div>
   <div *ngIf="viewMode === 'photos-inspections'" class="page-content">
+    <div class="photo-filters-row">
+      <mat-form-field appearance="outline" class="filter-field">
+        <mat-label>Filtrar por inspetor</mat-label>
+        <mat-select [(ngModel)]="selectedPhotoInspectorId" (selectionChange)="onPhotoInspectorFilterChange()">
+          <mat-option [value]="undefined">Todos</mat-option>
+          <mat-option *ngFor="let inspector of inspectorsDataSource.data" [value]="inspector.id">
+            {{ inspector.nome }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="filter-field">
+        <mat-label>Filtrar por inspeção</mat-label>
+        <mat-select [(ngModel)]="selectedPhotoInspectionId" (selectionChange)="onPhotoInspectionFilterChange()">
+          <mat-option [value]="undefined">Todas</mat-option>
+          <mat-option *ngFor="let inspection of inspectionsForSelectedInspector" [value]="inspection.id">
+            #{{ inspection.id }} - {{ inspection.client || inspection.name || 'Sem cliente' }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+
     <mat-form-field appearance="outline" class="filter-field">
       <mat-label>Buscar fotos de inspeção</mat-label>
       <input matInput (keyup)="applyPhotosInspectionsFilter($event)" placeholder="Digite ID da inspeção, URL ou descrição" />
@@ -199,9 +221,12 @@
           <td mat-cell *matCellDef="let row">{{ row.inspectionId || '-' }}</td>
         </ng-container>
 
-        <ng-container matColumnDef="photoUrl">
-          <th mat-header-cell *matHeaderCellDef>URL da foto</th>
-          <td mat-cell *matCellDef="let row">{{ row.photoUrl || '-' }}</td>
+        <ng-container matColumnDef="photoPreview">
+          <th mat-header-cell *matHeaderCellDef>Foto</th>
+          <td mat-cell *matCellDef="let row">
+            <img *ngIf="getPhotoPreview(row)" [src]="getPhotoPreview(row)!" alt="Foto da inspeção" class="inspection-photo-preview" />
+            <span *ngIf="!getPhotoPreview(row)">-</span>
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="descricao">
@@ -214,9 +239,34 @@
           <td mat-cell *matCellDef="let row">{{ row.createdAt || '-' }}</td>
         </ng-container>
 
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Ações</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="actions-cell">
+              <button mat-stroked-button color="primary" (click)="startEditPhoto(row)">Alterar foto</button>
+              <button mat-stroked-button color="warn" (click)="deletePhoto(row)">Excluir</button>
+            </div>
+          </td>
+        </ng-container>
+
         <tr mat-header-row *matHeaderRowDef="photosInspectionColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: photosInspectionColumns"></tr>
       </table>
+    </div>
+
+    <div class="editor-box mat-elevation-z2" *ngIf="photoEditing">
+      <h3>Alterar foto #{{ photoEditing.id }}</h3>
+      <div class="form-grid one-column">
+        <mat-form-field appearance="outline">
+          <mat-label>Descrição</mat-label>
+          <input matInput [(ngModel)]="photoEditing.descricao" />
+        </mat-form-field>
+        <input type="file" accept="image/*" (change)="onPhotoFileForUpdateSelected($event)" />
+      </div>
+      <div class="actions-row">
+        <button mat-raised-button color="primary" (click)="savePhotoChanges()">Salvar</button>
+        <button mat-stroked-button (click)="cancelEditPhoto()">Cancelar</button>
+      </div>
     </div>
   </div>
 

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
@@ -82,3 +82,17 @@ table {
 .upload-table table {
   min-width: 680px;
 }
+
+.photo-filters-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.inspection-photo-preview {
+  width: 140px;
+  height: 90px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+}

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
@@ -54,11 +54,14 @@ export class InspectionImportListComponent implements AfterViewInit {
   dataSource = new MatTableDataSource<Inspection>([]);
   inspectorsDataSource = new MatTableDataSource<Inspector>([]);
   photosInspectionsDataSource = new MatTableDataSource<PhotoInspection>([]);
+  allPhotosInspections: PhotoInspection[] = [];
 
   selectedFile?: File;
   selectedZipFile?: File;
   isLoading = false;
   selectedInspectorId?: number;
+  selectedPhotoInspectorId?: number;
+  selectedPhotoInspectionId?: number;
   uploadResult?: InspectionZipUploadResponse;
   processedPhotosDataSource = new MatTableDataSource<FotoProcessada>([]);
   unprocessedPhotosDataSource = new MatTableDataSource<FotoNaoProcessada>([]);
@@ -68,6 +71,8 @@ export class InspectionImportListComponent implements AfterViewInit {
   inspectionEditing?: Inspection;
   inspectionForInspectorAssign?: Inspection;
   inspectorEditing?: Inspector;
+  photoEditing?: PhotoInspection;
+  selectedPhotoFileForUpdate?: File;
 
   inspectorForm: Inspector = { nome: '' };
 
@@ -131,6 +136,9 @@ export class InspectionImportListComponent implements AfterViewInit {
       return;
     }
 
+    this.photosInspectionColumns = ['id', 'inspectionId', 'photoPreview', 'descricao', 'createdAt', 'actions'];
+    this.loadInspections();
+    this.loadInspectors();
     this.loadPhotosInspections();
   }
 
@@ -340,6 +348,81 @@ export class InspectionImportListComponent implements AfterViewInit {
     this.inspectorsDataSource.filter = filterValue.trim().toLowerCase();
   }
 
+  get inspectionsForSelectedInspector(): Inspection[] {
+    if (!this.selectedPhotoInspectorId) {
+      return this.dataSource.data;
+    }
+
+    return this.dataSource.data.filter((inspection) => inspection.inspetorId === this.selectedPhotoInspectorId);
+  }
+
+  get filteredPhotosInspections(): PhotoInspection[] {
+    return this.photosInspectionsDataSource.data;
+  }
+
+  onPhotoInspectorFilterChange(): void {
+    this.selectedPhotoInspectionId = undefined;
+    this.applyPhotoFilter();
+  }
+
+  onPhotoInspectionFilterChange(): void {
+    this.applyPhotoFilter();
+  }
+
+  onPhotoFileForUpdateSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedPhotoFileForUpdate = input.files?.[0];
+  }
+
+  startEditPhoto(row: PhotoInspection): void {
+    this.photoEditing = { ...row };
+    this.selectedPhotoFileForUpdate = undefined;
+  }
+
+  cancelEditPhoto(): void {
+    this.photoEditing = undefined;
+    this.selectedPhotoFileForUpdate = undefined;
+  }
+
+  savePhotoChanges(): void {
+    if (!this.photoEditing?.id || !this.selectedPhotoFileForUpdate) {
+      this.showMessage('Selecione uma foto para substituir.');
+      return;
+    }
+
+    this.inspectionService
+      .updatePhotoInspection(this.photoEditing.id, this.selectedPhotoFileForUpdate, this.photoEditing.descricao || '')
+      .subscribe({
+        next: () => {
+          this.showMessage('Foto atualizada com sucesso.');
+          this.cancelEditPhoto();
+          this.loadPhotosInspections();
+        },
+        error: () => this.showMessage('Não foi possível atualizar a foto.')
+      });
+  }
+
+  deletePhoto(row: PhotoInspection): void {
+    if (!confirm(`Deseja excluir a foto #${row.id}?`)) {
+      return;
+    }
+
+    this.inspectionService.deletePhotoInspection(row.id).subscribe({
+      next: () => {
+        this.showMessage('Foto excluída com sucesso.');
+        this.loadPhotosInspections();
+      },
+      error: () => this.showMessage('Não foi possível excluir a foto.')
+    });
+  }
+
+  getPhotoPreview(photo: PhotoInspection): string | null {
+    if (photo.foto) {
+      return `data:image/jpeg;base64,${photo.foto}`;
+    }
+
+    return photo.photoUrl || null;
+  }
 
   loadPhotosInspections(): void {
     this.isLoading = true;
@@ -348,7 +431,8 @@ export class InspectionImportListComponent implements AfterViewInit {
       .pipe(finalize(() => (this.isLoading = false)))
       .subscribe({
         next: (photosInspections) => {
-          this.photosInspectionsDataSource.data = photosInspections;
+          this.allPhotosInspections = photosInspections;
+          this.applyPhotoFilter();
         },
         error: () => this.showMessage('Não foi possível carregar as fotos de inspeções.')
       });
@@ -357,6 +441,22 @@ export class InspectionImportListComponent implements AfterViewInit {
   applyPhotosInspectionsFilter(event: Event): void {
     const filterValue = (event.target as HTMLInputElement).value;
     this.photosInspectionsDataSource.filter = filterValue.trim().toLowerCase();
+  }
+
+  private applyPhotoFilter(): void {
+    const filtered = this.allPhotosInspections.filter((photo) => {
+      if (this.selectedPhotoInspectionId) {
+        return photo.inspectionId === this.selectedPhotoInspectionId;
+      }
+
+      if (this.selectedPhotoInspectorId) {
+        return this.inspectionsForSelectedInspector.some((inspection) => inspection.id === photo.inspectionId);
+      }
+
+      return true;
+    });
+
+    this.photosInspectionsDataSource.data = filtered;
   }
 
   private resetInspectorForm(): void {

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -61,6 +61,21 @@ export class InspectionService {
     return this.http.get<PhotoInspection[]>(this.photosInspectionsApiUrl);
   }
 
+  updatePhotoInspection(id: number, photoFile: File, descricao?: string): Observable<PhotoInspection> {
+    const formData = new FormData();
+    formData.append('foto', photoFile);
+
+    if (descricao !== undefined && descricao !== null) {
+      formData.append('descricao', descricao);
+    }
+
+    return this.http.put<PhotoInspection>(`${this.photosInspectionsApiUrl}/${id}`, formData);
+  }
+
+  deletePhotoInspection(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.photosInspectionsApiUrl}/${id}`);
+  }
+
   uploadInspectionZip(file: File): Observable<InspectionZipUploadResponse> {
     const formData = new FormData();
     formData.append('file', file);

--- a/src/app/models/photo-inspection.model.ts
+++ b/src/app/models/photo-inspection.model.ts
@@ -1,6 +1,7 @@
 export interface PhotoInspection {
   id: number;
   inspectionId?: number | null;
+  foto?: string | null;
   photoUrl?: string | null;
   descricao?: string | null;
   createdAt?: string | null;


### PR DESCRIPTION
### Motivation
- Permitir visualizar o conteúdo da foto retornada pelo backend (Base64) na listagem de fotos de inspeção.
- Habilitar seleção de inspetor/inspeção para filtrar fotos relacionadas e possibilitar manutenção (substituir/excluir) direto na UI.

### Description
- Adiciona o campo `foto` ao modelo `PhotoInspection` para suportar Base64 vindo do backend (`src/app/models/photo-inspection.model.ts`).
- Estende `InspectionService` com `updatePhotoInspection` e `deletePhotoInspection` que enviam/remoção via `FormData` (`src/app/components/inspection/inspection.service.ts`).
- Atualiza o componente de listagem `InspectionImportListComponent` para carregar inspeções e inspetores, exibir preview da imagem (Base64 ou `photoUrl`), filtrar por inspetor e por inspeção, e permitir editar/substituir e excluir fotos (`src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts` e `.html`).
- Adiciona estilos para filtros e miniatura da foto (`src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss`).

### Testing
- `npm run build` falhou devido a bloqueio externo ao buscar Google Fonts (status 403) durante a etapa de inlining das fontes, por limitação de ambiente.
- `npm run build -- --configuration development` executou com sucesso e gerou o bundle em `dist/crm-security-front`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc9b2da7883228f85869285776baa)