### PR TITLE
feat: adicionar menu 'Pesquisa' com tela de busca de inspeções e popup de fotos

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -15,6 +15,7 @@ import {SolicitarDocumentoComponent} from './components/lead/solicitar-documento
 import {
   InspectionImportListComponent
 } from './components/inspection/inspection-import-list/inspection-import-list.component';
+import { InspectionSearchComponent } from './components/inspection/inspection-search/inspection-search.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
@@ -96,5 +97,17 @@ export const routes: Routes = [
     component: InspectionImportListComponent,
     canActivate: [AuthGuard],
     data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], view: 'inspection-upload' }
+  },
+  {
+    path: 'pesquisa/inspetor-worder',
+    component: InspectionSearchComponent,
+    canActivate: [AuthGuard],
+    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], mode: 'worder' }
+  },
+  {
+    path: 'pesquisa/atype',
+    component: InspectionSearchComponent,
+    canActivate: [AuthGuard],
+    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], mode: 'otype' }
   }
 ];

--- a/src/app/components/inspection/inspection-search/inspection-search.component.html
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.html
@@ -1,0 +1,118 @@
+<section class="page-wrapper">
+  <h2>Pesquisa de inspeções</h2>
+
+  <div class="search-box mat-elevation-z2">
+    <mat-form-field appearance="outline">
+      <mat-label>Inspetor</mat-label>
+      <mat-select [(ngModel)]="inspectorId">
+        <mat-option [value]="undefined">Todos</mat-option>
+        <mat-option *ngFor="let inspector of inspectors" [value]="inspector.id">
+          {{ inspector.nome }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>{{ searchMode === 'worder' ? 'Worder' : 'Otype' }}</mat-label>
+      <input
+        matInput
+        [(ngModel)]="searchValue"
+        [placeholder]="searchMode === 'worder' ? 'Digite o worder' : 'Digite o otype'"
+        (keydown)="onKeydownSearch($event)"
+      />
+    </mat-form-field>
+
+    <div class="actions-row">
+      <button mat-raised-button color="primary" (click)="searchByInspectorAndWorder()" [disabled]="isLoading">
+        Pesquisa inspetor/worder
+      </button>
+      <button mat-raised-button color="accent" (click)="searchByInspectorAndOtype()" [disabled]="isLoading">
+        Pesquisa/atype
+      </button>
+    </div>
+  </div>
+
+  <div class="table-wrapper mat-elevation-z2">
+    <h3>Inspeções encontradas</h3>
+    <table mat-table [dataSource]="inspectionsDataSource">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>Status</th>
+        <td mat-cell *matCellDef="let row">{{ row.status || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="worder">
+        <th mat-header-cell *matHeaderCellDef>Worder</th>
+        <td mat-cell *matCellDef="let row">{{ row.worder || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="otype">
+        <th mat-header-cell *matHeaderCellDef>Otype</th>
+        <td mat-cell *matCellDef="let row">{{ row.otype || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="client">
+        <th mat-header-cell *matHeaderCellDef>Cliente</th>
+        <td mat-cell *matCellDef="let row">{{ row.client || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Nome</th>
+        <td mat-cell *matCellDef="let row">{{ row.name || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="city">
+        <th mat-header-cell *matHeaderCellDef>Cidade</th>
+        <td mat-cell *matCellDef="let row">{{ row.city || '-' }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="inspectionColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: inspectionColumns"></tr>
+    </table>
+  </div>
+
+  <div class="table-wrapper mat-elevation-z2">
+    <h3>Lista de fotos</h3>
+    <table mat-table [dataSource]="photosDataSource">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="inspectionId">
+        <th mat-header-cell *matHeaderCellDef>Inspeção</th>
+        <td mat-cell *matCellDef="let row">{{ row.inspectionId || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="descricao">
+        <th mat-header-cell *matHeaderCellDef>Descrição</th>
+        <td mat-cell *matCellDef="let row">{{ row.descricao || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="preview">
+        <th mat-header-cell *matHeaderCellDef>Visualizar</th>
+        <td mat-cell *matCellDef="let row">
+          <button mat-stroked-button color="primary" (click)="openPhotoPopup(row)">
+            Ver foto
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="photoColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: photoColumns"></tr>
+    </table>
+  </div>
+
+  <div class="photo-modal" *ngIf="selectedPhotoPreview" (click)="closePhotoPopup()">
+    <div class="photo-modal-content" (click)="$event.stopPropagation()">
+      <button mat-icon-button class="close-button" (click)="closePhotoPopup()" aria-label="Fechar popup">
+        <mat-icon>close</mat-icon>
+      </button>
+      <img [src]="selectedPhotoPreview" alt="Foto da inspeção" />
+    </div>
+  </div>
+</section>

--- a/src/app/components/inspection/inspection-search/inspection-search.component.scss
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.scss
@@ -1,0 +1,66 @@
+.page-wrapper {
+  padding: 16px;
+}
+
+.search-box,
+.table-wrapper {
+  background: #fff;
+  border-radius: 8px;
+  padding: 12px;
+  margin-top: 16px;
+}
+
+.search-box {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+mat-form-field {
+  min-width: 260px;
+}
+
+table {
+  width: 100%;
+  min-width: 900px;
+}
+
+.photo-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+}
+
+.photo-modal-content {
+  position: relative;
+  background: #fff;
+  border-radius: 10px;
+  max-width: min(90vw, 980px);
+  max-height: 90vh;
+  padding: 12px;
+}
+
+.photo-modal-content img {
+  width: 100%;
+  max-height: calc(90vh - 24px);
+  object-fit: contain;
+  border-radius: 8px;
+}
+
+.close-button {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background-color: rgba(255, 255, 255, 0.8);
+}

--- a/src/app/components/inspection/inspection-search/inspection-search.component.ts
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.ts
@@ -1,0 +1,160 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { ActivatedRoute } from '@angular/router';
+import { finalize } from 'rxjs';
+
+import { Inspection } from '../../../models/inspection.model';
+import { Inspector } from '../../../models/inspector.model';
+import { PhotoInspection } from '../../../models/photo-inspection.model';
+import { InspectionService } from '../inspection.service';
+
+@Component({
+  selector: 'app-inspection-search',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSnackBarModule,
+    MatTableModule
+  ],
+  templateUrl: './inspection-search.component.html',
+  styleUrl: './inspection-search.component.scss'
+})
+export class InspectionSearchComponent implements OnInit {
+  searchMode: 'worder' | 'otype' = 'worder';
+
+  inspectorId?: number;
+  searchValue = '';
+  isLoading = false;
+
+  inspectors: Inspector[] = [];
+  inspectionsDataSource = new MatTableDataSource<Inspection>([]);
+  photosDataSource = new MatTableDataSource<PhotoInspection>([]);
+
+  selectedPhotoPreview?: string;
+
+  readonly inspectionColumns = ['id', 'status', 'worder', 'otype', 'client', 'name', 'city'];
+  readonly photoColumns = ['id', 'inspectionId', 'descricao', 'preview'];
+
+  constructor(
+    private inspectionService: InspectionService,
+    private snackBar: MatSnackBar,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit(): void {
+    const mode = this.route.snapshot.data['mode'];
+    if (mode === 'otype') {
+      this.searchMode = 'otype';
+    }
+
+    this.loadInspectors();
+  }
+
+  loadInspectors(): void {
+    this.inspectionService.listInspectors().subscribe({
+      next: (inspectors) => {
+        this.inspectors = inspectors;
+      },
+      error: () => this.showMessage('Não foi possível carregar os inspetores.')
+    });
+  }
+
+  searchByInspectorAndWorder(): void {
+    this.searchMode = 'worder';
+    this.searchInspections();
+  }
+
+  searchByInspectorAndOtype(): void {
+    this.searchMode = 'otype';
+    this.searchInspections();
+  }
+
+  onKeydownSearch(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      this.searchInspections();
+    }
+  }
+
+  openPhotoPopup(photo: PhotoInspection): void {
+    const preview = this.getPhotoPreview(photo);
+    if (!preview) {
+      this.showMessage('Foto sem visualização disponível.');
+      return;
+    }
+
+    this.selectedPhotoPreview = preview;
+  }
+
+  closePhotoPopup(): void {
+    this.selectedPhotoPreview = undefined;
+  }
+
+  getPhotoPreview(photo: PhotoInspection): string | null {
+    if (photo.foto) {
+      return `data:image/jpeg;base64,${photo.foto}`;
+    }
+
+    return photo.photoUrl || null;
+  }
+
+  private searchInspections(): void {
+    this.isLoading = true;
+
+    const request$ = this.searchMode === 'worder'
+      ? this.inspectionService.listInspectionsByWorder(this.inspectorId, this.searchValue)
+      : this.inspectionService.listInspectionsByOtype(this.inspectorId, this.searchValue);
+
+    request$
+      .pipe(finalize(() => (this.isLoading = false)))
+      .subscribe({
+        next: (inspections) => {
+          this.inspectionsDataSource.data = inspections;
+          this.loadPhotosByInspections(inspections);
+        },
+        error: () => {
+          this.inspectionsDataSource.data = [];
+          this.photosDataSource.data = [];
+          this.showMessage('Não foi possível pesquisar as inspeções.');
+        }
+      });
+  }
+
+  private loadPhotosByInspections(inspections: Inspection[]): void {
+    if (!inspections.length) {
+      this.photosDataSource.data = [];
+      return;
+    }
+
+    this.inspectionService.listPhotosByInspections(inspections).subscribe({
+      next: (photos) => {
+        this.photosDataSource.data = photos;
+      },
+      error: () => {
+        this.photosDataSource.data = [];
+        this.showMessage('Não foi possível carregar as fotos para as inspeções encontradas.');
+      }
+    });
+  }
+
+  private showMessage(message: string): void {
+    this.snackBar.open(message, 'Fechar', {
+      duration: 3500,
+      verticalPosition: 'top',
+      horizontalPosition: 'right'
+    });
+  }
+}

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { catchError, Observable, throwError } from 'rxjs';
 import { Inspection } from '../../models/inspection.model';
 import { Inspector } from '../../models/inspector.model';
@@ -21,6 +21,34 @@ export class InspectionService {
 
   listInspections(): Observable<Inspection[]> {
     return this.http.get<Inspection[]>(this.inspectionsApiUrl);
+  }
+
+  listInspectionsByWorder(inspetorId?: number, worder?: string): Observable<Inspection[]> {
+    let params = new HttpParams();
+
+    if (inspetorId) {
+      params = params.set('inspetorId', String(inspetorId));
+    }
+
+    if (worder?.trim()) {
+      params = params.set('worder', worder.trim());
+    }
+
+    return this.http.get<Inspection[]>(`${this.inspectionsApiUrl}/por-worder`, { params });
+  }
+
+  listInspectionsByOtype(inspetorId?: number, otype?: string): Observable<Inspection[]> {
+    let params = new HttpParams();
+
+    if (inspetorId) {
+      params = params.set('inspetorId', String(inspetorId));
+    }
+
+    if (otype?.trim()) {
+      params = params.set('otype', otype.trim());
+    }
+
+    return this.http.get<Inspection[]>(`${this.inspectionsApiUrl}/por-otype`, { params });
   }
 
   uploadExcel(file: File): Observable<void> {
@@ -59,6 +87,10 @@ export class InspectionService {
 
   listPhotosInspections(): Observable<PhotoInspection[]> {
     return this.http.get<PhotoInspection[]>(this.photosInspectionsApiUrl);
+  }
+
+  listPhotosByInspections(inspections: Inspection[]): Observable<PhotoInspection[]> {
+    return this.http.post<PhotoInspection[]>(`${this.photosInspectionsApiUrl}/by-inspections`, inspections);
   }
 
   updatePhotoInspection(id: number, photoFile: File, descricao?: string): Observable<PhotoInspection> {

--- a/src/app/components/template/nav/nav.component.css
+++ b/src/app/components/template/nav/nav.component.css
@@ -12,9 +12,20 @@
     padding-right: 10px;
 }
 
+.submenu-arrow {
+    margin-left: auto;
+}
+
+.submenu-wrapper {
+    padding-left: 16px;
+}
+
+.submenu-item {
+    font-size: 13px;
+}
+
 .content {
     padding: 16px;
     background-color: #fff;
 }
-
 

--- a/src/app/components/template/nav/nav.component.html
+++ b/src/app/components/template/nav/nav.component.html
@@ -10,6 +10,27 @@
           {{ item.label }}
         </a>
       </ng-container>
+
+      <ng-container *ngIf="canShow(['ROLE_ADMIN', 'ROLE_CORRETOR'])">
+        <a mat-list-item (click)="pesquisaExpanded = !pesquisaExpanded">
+          <mat-icon>search</mat-icon>
+          Pesquisa
+          <mat-icon class="submenu-arrow">{{ pesquisaExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+        </a>
+
+        <div class="submenu-wrapper" *ngIf="pesquisaExpanded">
+          <a
+            *ngFor="let item of pesquisaSubmenuItems"
+            [hidden]="!canShow(item.roles)"
+            mat-list-item
+            class="submenu-item"
+            [routerLink]="item.route"
+          >
+            {{ item.label }}
+          </a>
+        </div>
+      </ng-container>
+
       <!-- Botão de sair -->
       <a *ngIf="authService.isAuthenticated()" (click)="logout()" mat-list-item>
         <mat-icon>logout</mat-icon>

--- a/src/app/components/template/nav/nav.component.ts
+++ b/src/app/components/template/nav/nav.component.ts
@@ -23,7 +23,7 @@ import { AuthService } from '../../../auth/services/auth.service';
   styleUrl: './nav.component.css'
 })
 export class NavComponent {
-
+  pesquisaExpanded = false;
 
   constructor(public authService: AuthService) {}
 
@@ -39,6 +39,19 @@ export class NavComponent {
     { label: 'Upload de inspeção', icon: 'folder_zip', route: '/inspection-upload', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Usuários', icon: 'people', route: '/users', roles: ['ROLE_ADMIN'] },
     { label: 'Cadastrar Usuário', icon: 'person_add', route: '/register', roles: ['ROLE_ADMIN'] }  ];
+
+  pesquisaSubmenuItems = [
+    {
+      label: 'Pesquisa inspetor/worder',
+      route: '/pesquisa/inspetor-worder',
+      roles: ['ROLE_ADMIN', 'ROLE_CORRETOR']
+    },
+    {
+      label: 'Pesquisa/atype',
+      route: '/pesquisa/atype',
+      roles: ['ROLE_ADMIN', 'ROLE_CORRETOR']
+    }
+  ];
 
   logout() {
     this.authService.logout();


### PR DESCRIPTION
### Motivation
- Adicionar uma opção de pesquisa no nav para permitir busca de inspeções por inspetor + `worder` e por inspetor + `otype` e exibir fotos relacionadas em uma única tela.  
- Mostrar as fotos retornadas e permitir visualização em popup para facilitar a inspeção rápida das imagens.  

### Description
- Inclui novo agrupador no menu lateral `Pesquisa` com dois submenus: `Pesquisa inspetor/worder` e `Pesquisa/atype`, visíveis para as roles apropriadas e com expansão/colapso (arquivos modificados: `nav.component.ts`, `nav.component.html`, `nav.component.css`).  
- Criei o componente standalone `InspectionSearchComponent` com filtros por inspetor, pesquisa por `worder`/`otype`, tabela de `Inspection` e tabela de fotos, além de modal/popup para visualização de fotos (`inspection-search.component.ts`, `.html`, `.scss`).  
- Adicionei rotas protegidas `/pesquisa/inspetor-worder` e `/pesquisa/atype` que carregam o componente em modos distintos conforme `data.mode` (`app.routes.ts`).  
- Estendi `InspectionService` com chamadas aos endpoints backend fornecidos: `GET /api/inspections/por-worder`, `GET /api/inspections/por-otype` e `POST /api/foto-inspections/by-inspections` (`inspection.service.ts`).  

### Testing
- Executado `npm run build -- --configuration development` e o build de desenvolvimento completou com sucesso.  
- Executado `npm run build` (build padrão) que falhou devido a inlining de fontes externas (`Google Fonts` retornando HTTP 403) em ambiente restrito; isso é uma limitação do ambiente e não do código.  
- Nenhum teste unitário adicional foi executado neste passo de integração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be1aa30b04832286109daa362950ec)