### PR TITLE
Separar pesquisas de inspeção por página e carregar fotos sob demanda

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -106,6 +106,12 @@ export const routes: Routes = [
   },
   {
     path: 'pesquisa/atype',
+    redirectTo: 'pesquisa/otype',
+    pathMatch: 'full'
+  },
+
+  {
+    path: 'pesquisa/otype',
     component: InspectionSearchComponent,
     canActivate: [AuthGuard],
     data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], mode: 'otype' }

--- a/src/app/components/inspection/inspection-search/inspection-search.component.html
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.html
@@ -1,5 +1,5 @@
 <section class="page-wrapper">
-  <h2>Pesquisa de inspeções</h2>
+  <h2>{{ searchTitle }}</h2>
 
   <div class="search-box mat-elevation-z2">
     <mat-form-field appearance="outline">
@@ -13,27 +13,26 @@
     </mat-form-field>
 
     <mat-form-field appearance="outline">
-      <mat-label>{{ searchMode === 'worder' ? 'Worder' : 'Otype' }}</mat-label>
+      <mat-label>{{ searchLabel }}</mat-label>
       <input
         matInput
         [(ngModel)]="searchValue"
-        [placeholder]="searchMode === 'worder' ? 'Digite o worder' : 'Digite o otype'"
+        [placeholder]="searchPlaceholder"
         (keydown)="onKeydownSearch($event)"
       />
     </mat-form-field>
 
     <div class="actions-row">
-      <button mat-raised-button color="primary" (click)="searchByInspectorAndWorder()" [disabled]="isLoading">
-        Pesquisa inspetor/worder
-      </button>
-      <button mat-raised-button color="accent" (click)="searchByInspectorAndOtype()" [disabled]="isLoading">
-        Pesquisa/atype
+      <button mat-raised-button color="primary" (click)="search()" [disabled]="isLoading">
+        Pesquisar
       </button>
     </div>
   </div>
 
   <div class="table-wrapper mat-elevation-z2">
     <h3>Inspeções encontradas</h3>
+    <p class="helper-text">Clique em uma inspeção para carregar as fotos relacionadas.</p>
+
     <table mat-table [dataSource]="inspectionsDataSource">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef>ID</th>
@@ -71,12 +70,25 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="inspectionColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: inspectionColumns"></tr>
+      <tr
+        mat-row
+        *matRowDef="let row; columns: inspectionColumns"
+        (click)="selectInspection(row)"
+        [class.row-selected]="isInspectionSelected(row)"
+      ></tr>
     </table>
   </div>
 
   <div class="table-wrapper mat-elevation-z2">
     <h3>Lista de fotos</h3>
+
+    <p class="helper-text" *ngIf="!selectedInspectionId">
+      Selecione uma inspeção para visualizar as fotos.
+    </p>
+    <p class="helper-text" *ngIf="isLoadingPhotos">
+      Carregando fotos da inspeção selecionada...
+    </p>
+
     <table mat-table [dataSource]="photosDataSource">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef>ID</th>

--- a/src/app/components/inspection/inspection-search/inspection-search.component.scss
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.scss
@@ -32,6 +32,23 @@ table {
   min-width: 900px;
 }
 
+.helper-text {
+  margin: 8px 0 12px;
+  color: #666;
+}
+
+.mat-mdc-row {
+  cursor: pointer;
+}
+
+.mat-mdc-row:hover {
+  background: #f5f8ff;
+}
+
+.row-selected {
+  background: #e8f0fe;
+}
+
 .photo-modal {
   position: fixed;
   inset: 0;

--- a/src/app/components/inspection/inspection-search/inspection-search.component.ts
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.ts
@@ -39,11 +39,13 @@ export class InspectionSearchComponent implements OnInit {
   inspectorId?: number;
   searchValue = '';
   isLoading = false;
+  isLoadingPhotos = false;
 
   inspectors: Inspector[] = [];
   inspectionsDataSource = new MatTableDataSource<Inspection>([]);
   photosDataSource = new MatTableDataSource<PhotoInspection>([]);
 
+  selectedInspectionId?: number;
   selectedPhotoPreview?: string;
 
   readonly inspectionColumns = ['id', 'status', 'worder', 'otype', 'client', 'name', 'city'];
@@ -64,6 +66,18 @@ export class InspectionSearchComponent implements OnInit {
     this.loadInspectors();
   }
 
+  get searchTitle(): string {
+    return this.searchMode === 'worder' ? 'Pesquisa por Worder' : 'Pesquisa por Otype';
+  }
+
+  get searchLabel(): string {
+    return this.searchMode === 'worder' ? 'Worder' : 'Otype';
+  }
+
+  get searchPlaceholder(): string {
+    return this.searchMode === 'worder' ? 'Digite o worder' : 'Digite o otype';
+  }
+
   loadInspectors(): void {
     this.inspectionService.listInspectors().subscribe({
       next: (inspectors) => {
@@ -73,13 +87,7 @@ export class InspectionSearchComponent implements OnInit {
     });
   }
 
-  searchByInspectorAndWorder(): void {
-    this.searchMode = 'worder';
-    this.searchInspections();
-  }
-
-  searchByInspectorAndOtype(): void {
-    this.searchMode = 'otype';
+  search(): void {
     this.searchInspections();
   }
 
@@ -87,6 +95,29 @@ export class InspectionSearchComponent implements OnInit {
     if (event.key === 'Enter') {
       this.searchInspections();
     }
+  }
+
+  selectInspection(inspection: Inspection): void {
+    if (!inspection.id) {
+      this.showMessage('Inspeção inválida para carregar fotos.');
+      return;
+    }
+
+    this.selectedInspectionId = inspection.id;
+    this.photosDataSource.data = [];
+    this.isLoadingPhotos = true;
+
+    this.inspectionService.listPhotosByInspections([inspection]).pipe(
+      finalize(() => (this.isLoadingPhotos = false))
+    ).subscribe({
+      next: (photos) => {
+        this.photosDataSource.data = photos;
+      },
+      error: () => {
+        this.photosDataSource.data = [];
+        this.showMessage('Não foi possível carregar as fotos da inspeção selecionada.');
+      }
+    });
   }
 
   openPhotoPopup(photo: PhotoInspection): void {
@@ -111,8 +142,14 @@ export class InspectionSearchComponent implements OnInit {
     return photo.photoUrl || null;
   }
 
+  isInspectionSelected(inspection: Inspection): boolean {
+    return Boolean(inspection.id && inspection.id === this.selectedInspectionId);
+  }
+
   private searchInspections(): void {
     this.isLoading = true;
+    this.selectedInspectionId = undefined;
+    this.photosDataSource.data = [];
 
     const request$ = this.searchMode === 'worder'
       ? this.inspectionService.listInspectionsByWorder(this.inspectorId, this.searchValue)
@@ -123,7 +160,6 @@ export class InspectionSearchComponent implements OnInit {
       .subscribe({
         next: (inspections) => {
           this.inspectionsDataSource.data = inspections;
-          this.loadPhotosByInspections(inspections);
         },
         error: () => {
           this.inspectionsDataSource.data = [];
@@ -131,23 +167,6 @@ export class InspectionSearchComponent implements OnInit {
           this.showMessage('Não foi possível pesquisar as inspeções.');
         }
       });
-  }
-
-  private loadPhotosByInspections(inspections: Inspection[]): void {
-    if (!inspections.length) {
-      this.photosDataSource.data = [];
-      return;
-    }
-
-    this.inspectionService.listPhotosByInspections(inspections).subscribe({
-      next: (photos) => {
-        this.photosDataSource.data = photos;
-      },
-      error: () => {
-        this.photosDataSource.data = [];
-        this.showMessage('Não foi possível carregar as fotos para as inspeções encontradas.');
-      }
-    });
   }
 
   private showMessage(message: string): void {

--- a/src/app/components/template/nav/nav.component.ts
+++ b/src/app/components/template/nav/nav.component.ts
@@ -42,13 +42,13 @@ export class NavComponent {
 
   pesquisaSubmenuItems = [
     {
-      label: 'Pesquisa inspetor/worder',
+      label: 'Pesquisa por Worder',
       route: '/pesquisa/inspetor-worder',
       roles: ['ROLE_ADMIN', 'ROLE_CORRETOR']
     },
     {
-      label: 'Pesquisa/atype',
-      route: '/pesquisa/atype',
+      label: 'Pesquisa por Otype',
+      route: '/pesquisa/otype',
       roles: ['ROLE_ADMIN', 'ROLE_CORRETOR']
     }
   ];


### PR DESCRIPTION
### Motivation
- Evitar a confusão de ter dois botões de pesquisa na mesma tela, exibindo uma única pesquisa por contexto (Worder ou Otype) em páginas separadas.
- Fazer com que a lista de fotos não seja carregada automaticamente para múltiplas inspeções, mostrando fotos apenas quando o usuário selecionar uma inspeção.
- Atualizar rotas e navegação para refletir os novos caminhos/contextos de pesquisa e manter compatibilidade com URLs antigas.

### Description
- Refatorei `InspectionSearchComponent` para usar o modo da rota (`mode: 'worder' | 'otype'`) e adicionei getters `searchTitle`, `searchLabel` e `searchPlaceholder` para contextualizar título/label/placeholder; removi os dois botões e unifiquei em um único `search()` que chama `listInspectionsByWorder` ou `listInspectionsByOtype` conforme `searchMode` (`src/app/components/inspection/inspection-search/inspection-search.component.ts`).
- Alterei o fluxo de fotos para não carregar automaticamente após a busca; adicionei `selectInspection(inspection)` que carrega fotos somente para a inspeção selecionada e controla `selectedInspectionId` e `isLoadingPhotos`, removendo a chamada automática que buscava fotos para todas as inspeções encontradas (`src/app/components/inspection/inspection-search/inspection-search.component.ts`).
- Atualizei o template para: mostrar uma única linha de ação com botão `Pesquisar`, tornar as linhas de inspeção clicáveis, exibir textos auxiliares e destacar a inspeção selecionada (`inspection-search.component.html` e `inspection-search.component.scss`).
- Atualizei rotas e navegação para renomear e apontar para o novo caminho `pesquisa/otype` e adicionei redirecionamento de compatibilidade de `/pesquisa/atype` para `/pesquisa/otype`, além de renomear labels no menu para `Pesquisa por Worder` e `Pesquisa por Otype` (`src/app/app.routes.ts` e `src/app/components/template/nav/nav.component.ts`).

### Testing
- `npx ng build --configuration development` completed successfully and produced the application bundle.
- `npm run build` (production) failed in this environment due to an external font inlining error (Google Fonts returned HTTP 403), unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2766c0508322a23224928b06dd91)