### PR TITLE
feat: adicionar fluxo de visualização de inspeção na pesquisa

### DIFF
--- a/src/app/components/inspection/inspection-search/inspection-search.component.html
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.html
@@ -31,7 +31,7 @@
 
   <div class="table-wrapper mat-elevation-z2">
     <h3>Inspeções encontradas</h3>
-    <p class="helper-text">Clique em uma inspeção para carregar as fotos relacionadas.</p>
+    <p class="helper-text">Clique em Visualizar para carregar os dados completos e as fotos da inspeção.</p>
 
     <table mat-table [dataSource]="inspectionsDataSource">
       <ng-container matColumnDef="id">
@@ -69,21 +69,40 @@
         <td mat-cell *matCellDef="let row">{{ row.city || '-' }}</td>
       </ng-container>
 
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Ações</th>
+        <td mat-cell *matCellDef="let row">
+          <button mat-stroked-button color="primary" (click)="selectInspection(row)">
+            Visualizar
+          </button>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="inspectionColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: inspectionColumns"
-        (click)="selectInspection(row)"
         [class.row-selected]="isInspectionSelected(row)"
       ></tr>
     </table>
+  </div>
+
+  <div class="inspection-details mat-elevation-z2" *ngIf="selectedInspection">
+    <h3>Dados completos da inspeção</h3>
+
+    <div class="details-grid">
+      <div class="detail-item" *ngFor="let field of inspectionDetailsFields">
+        <span class="detail-label">{{ field.label }}</span>
+        <span class="detail-value">{{ getInspectionFieldValue(selectedInspection, field.key) }}</span>
+      </div>
+    </div>
   </div>
 
   <div class="table-wrapper mat-elevation-z2">
     <h3>Lista de fotos</h3>
 
     <p class="helper-text" *ngIf="!selectedInspectionId">
-      Selecione uma inspeção para visualizar as fotos.
+      Selecione uma inspeção e clique em Visualizar para carregar as fotos.
     </p>
     <p class="helper-text" *ngIf="isLoadingPhotos">
       Carregando fotos da inspeção selecionada...

--- a/src/app/components/inspection/inspection-search/inspection-search.component.scss
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.scss
@@ -3,7 +3,8 @@
 }
 
 .search-box,
-.table-wrapper {
+.table-wrapper,
+.inspection-details {
   background: #fff;
   border-radius: 8px;
   padding: 12px;
@@ -37,16 +38,40 @@ table {
   color: #666;
 }
 
-.mat-mdc-row {
-  cursor: pointer;
-}
-
 .mat-mdc-row:hover {
   background: #f5f8ff;
 }
 
 .row-selected {
   background: #e8f0fe;
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid #ececec;
+  border-radius: 6px;
+  background: #fafafa;
+}
+
+.detail-label {
+  font-size: 12px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.detail-value {
+  font-size: 14px;
+  color: #222;
 }
 
 .photo-modal {

--- a/src/app/components/inspection/inspection-search/inspection-search.component.ts
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.ts
@@ -46,10 +46,41 @@ export class InspectionSearchComponent implements OnInit {
   photosDataSource = new MatTableDataSource<PhotoInspection>([]);
 
   selectedInspectionId?: number;
+  selectedInspection?: Inspection;
   selectedPhotoPreview?: string;
 
-  readonly inspectionColumns = ['id', 'status', 'worder', 'otype', 'client', 'name', 'city'];
+  readonly inspectionColumns = ['id', 'status', 'worder', 'otype', 'client', 'name', 'city', 'actions'];
   readonly photoColumns = ['id', 'inspectionId', 'descricao', 'preview'];
+  readonly inspectionDetailsFields: Array<{ key: keyof Inspection; label: string }> = [
+    { key: 'id', label: 'ID' },
+    { key: 'status', label: 'Status' },
+    { key: 'worder', label: 'Worder' },
+    { key: 'otype', label: 'Otype' },
+    { key: 'inspetorId', label: 'ID do Inspetor' },
+    { key: 'inspector', label: 'Inspetor' },
+    { key: 'client', label: 'Cliente' },
+    { key: 'name', label: 'Nome' },
+    { key: 'address1', label: 'Endereço 1' },
+    { key: 'address2', label: 'Endereço 2' },
+    { key: 'city', label: 'Cidade' },
+    { key: 'zip', label: 'CEP' },
+    { key: 'duedate', label: 'Vencimento' },
+    { key: 'rush', label: 'Rush' },
+    { key: 'followup', label: 'Follow Up' },
+    { key: 'vacant', label: 'Vacant' },
+    { key: 'mortgage', label: 'Mortgage' },
+    { key: 'vandalism', label: 'Vandalism' },
+    { key: 'freezeFlag', label: 'Freeze Flag' },
+    { key: 'storm', label: 'Storm' },
+    { key: 'roof', label: 'Roof' },
+    { key: 'water', label: 'Water' },
+    { key: 'naturalFlag', label: 'Natural Flag' },
+    { key: 'fire', label: 'Fire' },
+    { key: 'hazard', label: 'Hazard' },
+    { key: 'structure', label: 'Structure' },
+    { key: 'mold', label: 'Mold' },
+    { key: 'pump', label: 'Pump' }
+  ];
 
   constructor(
     private inspectionService: InspectionService,
@@ -104,6 +135,7 @@ export class InspectionSearchComponent implements OnInit {
     }
 
     this.selectedInspectionId = inspection.id;
+    this.selectedInspection = inspection;
     this.photosDataSource.data = [];
     this.isLoadingPhotos = true;
 
@@ -146,9 +178,15 @@ export class InspectionSearchComponent implements OnInit {
     return Boolean(inspection.id && inspection.id === this.selectedInspectionId);
   }
 
+  getInspectionFieldValue(inspection: Inspection, key: keyof Inspection): string | number {
+    const value = inspection[key];
+    return value !== null && value !== undefined && value !== '' ? value : '-';
+  }
+
   private searchInspections(): void {
     this.isLoading = true;
     this.selectedInspectionId = undefined;
+    this.selectedInspection = undefined;
     this.photosDataSource.data = [];
 
     const request$ = this.searchMode === 'worder'


### PR DESCRIPTION
### Motivation
- Tornar a tela de pesquisa de inspeções compatível com o fluxo: pesquisar -> listar -> visualizar detalhes + fotos na mesma tela sem depender do clique direto na linha. 
- Permitir que cada inspeção exibida tenha um botão `Visualizar` que abra um card com todos os dados da inspeção e carregue as fotos vinculadas.

### Description
- Adiciona coluna de ações na tabela com botão `Visualizar` para cada linha e remove a dependência de clique na linha para seleção. 
- Introduz estado `selectedInspection` e `inspectionDetailsFields` e a função `getInspectionFieldValue` para renderizar o card com os dados completos da inspeção selecionada. 
- Mantém o carregamento das fotos via `selectInspection(...)` chamando `inspectionService.listPhotosByInspections(...)` e preserva a exibição de fotos no mesmo contexto da tela. 
- Ajusta a marcação e estilos (`inspection-search.component.html`, `.ts`, `.scss`) para incluir o card de detalhes (grid de campos) e atualizar textos auxiliares sobre o novo fluxo.

### Testing
- `npm run build` — falhou no ambiente devido a inliner de fontes do Google retornando `403`, problema de ambiente externo (não relacionado à mudança funcional). 
- `npm run build -- --configuration development` — passou e gerou bundle em `dist/crm-security-front`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2be4ad748322a143cd8eec26777d)