### PR TITLE
feat: paginação, reposicionamento do card de inspeção e edição de metadados das fotos

### DIFF
--- a/src/app/components/inspection/inspection-search/inspection-search.component.html
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.html
@@ -29,6 +29,87 @@
     </div>
   </div>
 
+  <div class="inspection-details mat-elevation-z2" *ngIf="selectedInspection">
+    <h3>Dados completos da inspeção</h3>
+
+    <div class="details-grid">
+      <div class="detail-item" *ngFor="let field of inspectionDetailsFields">
+        <span class="detail-label">{{ field.label }}</span>
+        <span class="detail-value">{{ getInspectionFieldValue(selectedInspection, field.key) }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="table-wrapper mat-elevation-z2">
+    <h3>Lista de fotos</h3>
+
+    <p class="helper-text" *ngIf="!selectedInspectionId">
+      Selecione uma inspeção e clique em Visualizar para carregar as fotos.
+    </p>
+    <p class="helper-text" *ngIf="isLoadingPhotos">
+      Carregando fotos da inspeção selecionada...
+    </p>
+
+    <table mat-table [dataSource]="photosDataSource">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="inspectionId">
+        <th mat-header-cell *matHeaderCellDef>Inspeção</th>
+        <td mat-cell *matCellDef="let row">{{ row.inspectionId || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="descricao">
+        <th mat-header-cell *matHeaderCellDef>Descrição</th>
+        <td mat-cell *matCellDef="let row">{{ row.descricao || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="preview">
+        <th mat-header-cell *matHeaderCellDef>Visualizar</th>
+        <td mat-cell *matCellDef="let row">
+          <div class="photo-actions">
+            <button mat-stroked-button color="primary" (click)="openPhotoPopup(row)">
+              Ver foto
+            </button>
+            <button mat-stroked-button (click)="startEditPhoto(row)">
+              Editar
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="photoColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: photoColumns"></tr>
+    </table>
+  </div>
+
+  <div class="photo-editor mat-elevation-z2" *ngIf="photoEditing">
+    <h3>Editar metadados da foto #{{ photoEditing.id }}</h3>
+
+    <div class="photo-editor-fields">
+      <mat-form-field appearance="outline">
+        <mat-label>Descrição</mat-label>
+        <input matInput [(ngModel)]="photoEditing.descricao" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>URL da foto</mat-label>
+        <input matInput [(ngModel)]="photoEditing.photoUrl" />
+      </mat-form-field>
+    </div>
+
+    <div class="actions-row">
+      <button mat-raised-button color="primary" (click)="savePhotoMetadata()" [disabled]="isSavingPhoto">
+        Salvar
+      </button>
+      <button mat-stroked-button (click)="cancelEditPhoto()" [disabled]="isSavingPhoto">
+        Cancelar
+      </button>
+    </div>
+  </div>
+
   <div class="table-wrapper mat-elevation-z2">
     <h3>Inspeções encontradas</h3>
     <p class="helper-text">Clique em Visualizar para carregar os dados completos e as fotos da inspeção.</p>
@@ -85,57 +166,8 @@
         [class.row-selected]="isInspectionSelected(row)"
       ></tr>
     </table>
-  </div>
 
-  <div class="inspection-details mat-elevation-z2" *ngIf="selectedInspection">
-    <h3>Dados completos da inspeção</h3>
-
-    <div class="details-grid">
-      <div class="detail-item" *ngFor="let field of inspectionDetailsFields">
-        <span class="detail-label">{{ field.label }}</span>
-        <span class="detail-value">{{ getInspectionFieldValue(selectedInspection, field.key) }}</span>
-      </div>
-    </div>
-  </div>
-
-  <div class="table-wrapper mat-elevation-z2">
-    <h3>Lista de fotos</h3>
-
-    <p class="helper-text" *ngIf="!selectedInspectionId">
-      Selecione uma inspeção e clique em Visualizar para carregar as fotos.
-    </p>
-    <p class="helper-text" *ngIf="isLoadingPhotos">
-      Carregando fotos da inspeção selecionada...
-    </p>
-
-    <table mat-table [dataSource]="photosDataSource">
-      <ng-container matColumnDef="id">
-        <th mat-header-cell *matHeaderCellDef>ID</th>
-        <td mat-cell *matCellDef="let row">{{ row.id }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="inspectionId">
-        <th mat-header-cell *matHeaderCellDef>Inspeção</th>
-        <td mat-cell *matCellDef="let row">{{ row.inspectionId || '-' }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="descricao">
-        <th mat-header-cell *matHeaderCellDef>Descrição</th>
-        <td mat-cell *matCellDef="let row">{{ row.descricao || '-' }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="preview">
-        <th mat-header-cell *matHeaderCellDef>Visualizar</th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-stroked-button color="primary" (click)="openPhotoPopup(row)">
-            Ver foto
-          </button>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="photoColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: photoColumns"></tr>
-    </table>
+    <mat-paginator [pageSize]="10" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons></mat-paginator>
   </div>
 
   <div class="photo-modal" *ngIf="selectedPhotoPreview" (click)="closePhotoPopup()">

--- a/src/app/components/inspection/inspection-search/inspection-search.component.scss
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.scss
@@ -4,7 +4,8 @@
 
 .search-box,
 .table-wrapper,
-.inspection-details {
+.inspection-details,
+.photo-editor {
   background: #fff;
   border-radius: 8px;
   padding: 12px;
@@ -72,6 +73,18 @@ table {
 .detail-value {
   font-size: 14px;
   color: #222;
+}
+
+.photo-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.photo-editor-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
 }
 
 .photo-modal {

--- a/src/app/components/inspection/inspection-search/inspection-search.component.ts
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -7,6 +7,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { ActivatedRoute } from '@angular/router';
 import { finalize } from 'rxjs';
@@ -28,12 +29,15 @@ import { InspectionService } from '../inspection.service';
     MatInputModule,
     MatSelectModule,
     MatSnackBarModule,
+    MatPaginatorModule,
     MatTableModule
   ],
   templateUrl: './inspection-search.component.html',
   styleUrl: './inspection-search.component.scss'
 })
-export class InspectionSearchComponent implements OnInit {
+export class InspectionSearchComponent implements OnInit, AfterViewInit {
+  @ViewChild(MatPaginator) paginator?: MatPaginator;
+
   searchMode: 'worder' | 'otype' = 'worder';
 
   inspectorId?: number;
@@ -48,6 +52,9 @@ export class InspectionSearchComponent implements OnInit {
   selectedInspectionId?: number;
   selectedInspection?: Inspection;
   selectedPhotoPreview?: string;
+  photoEditing?: PhotoInspection;
+  isSavingPhoto = false;
+  readonly pageSizeOptions = [5, 10, 15, 20];
 
   readonly inspectionColumns = ['id', 'status', 'worder', 'otype', 'client', 'name', 'city', 'actions'];
   readonly photoColumns = ['id', 'inspectionId', 'descricao', 'preview'];
@@ -97,6 +104,10 @@ export class InspectionSearchComponent implements OnInit {
     this.loadInspectors();
   }
 
+  ngAfterViewInit(): void {
+    this.inspectionsDataSource.paginator = this.paginator ?? null;
+  }
+
   get searchTitle(): string {
     return this.searchMode === 'worder' ? 'Pesquisa por Worder' : 'Pesquisa por Otype';
   }
@@ -136,6 +147,7 @@ export class InspectionSearchComponent implements OnInit {
 
     this.selectedInspectionId = inspection.id;
     this.selectedInspection = inspection;
+    this.photoEditing = undefined;
     this.photosDataSource.data = [];
     this.isLoadingPhotos = true;
 
@@ -166,6 +178,35 @@ export class InspectionSearchComponent implements OnInit {
     this.selectedPhotoPreview = undefined;
   }
 
+  startEditPhoto(photo: PhotoInspection): void {
+    this.photoEditing = { ...photo };
+  }
+
+  cancelEditPhoto(): void {
+    this.photoEditing = undefined;
+  }
+
+  savePhotoMetadata(): void {
+    if (!this.photoEditing) {
+      return;
+    }
+
+    this.isSavingPhoto = true;
+    this.inspectionService
+      .updatePhotoInspectionMetadata(this.photoEditing)
+      .pipe(finalize(() => (this.isSavingPhoto = false)))
+      .subscribe({
+        next: (updatedPhoto) => {
+          this.photosDataSource.data = this.photosDataSource.data.map((photo) =>
+            photo.id === updatedPhoto.id ? { ...photo, ...updatedPhoto } : photo
+          );
+          this.photoEditing = undefined;
+          this.showMessage('Dados da foto atualizados com sucesso.');
+        },
+        error: () => this.showMessage('Não foi possível atualizar os dados da foto.')
+      });
+  }
+
   getPhotoPreview(photo: PhotoInspection): string | null {
     if (photo.foto) {
       return `data:image/jpeg;base64,${photo.foto}`;
@@ -187,6 +228,7 @@ export class InspectionSearchComponent implements OnInit {
     this.isLoading = true;
     this.selectedInspectionId = undefined;
     this.selectedInspection = undefined;
+    this.photoEditing = undefined;
     this.photosDataSource.data = [];
 
     const request$ = this.searchMode === 'worder'
@@ -198,6 +240,9 @@ export class InspectionSearchComponent implements OnInit {
       .subscribe({
         next: (inspections) => {
           this.inspectionsDataSource.data = inspections;
+          if (this.paginator) {
+            this.paginator.firstPage();
+          }
         },
         error: () => {
           this.inspectionsDataSource.data = [];

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -104,6 +104,13 @@ export class InspectionService {
     return this.http.put<PhotoInspection>(`${this.photosInspectionsApiUrl}/${id}`, formData);
   }
 
+  updatePhotoInspectionMetadata(photo: PhotoInspection): Observable<PhotoInspection> {
+    return this.http.put<PhotoInspection>(`${this.photosInspectionsApiUrl}/${photo.id}`, {
+      descricao: photo.descricao ?? null,
+      photoUrl: photo.photoUrl ?? null
+    });
+  }
+
   deletePhotoInspection(id: number): Observable<void> {
     return this.http.delete<void>(`${this.photosInspectionsApiUrl}/${id}`);
   }


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade da tela de pesquisa de inspeções com paginação e permitir edição rápida dos metadados das fotos sem upload de binário.
- Exibir o card de detalhes e a galeria de fotos acima da lista de inspeções para facilitar a leitura e edição após uma busca.

### Description
- Adiciona `MatPaginator` à tabela de inspeções com opções de página `5, 10, 15, 20` e reset para a primeira página após nova busca (`inspectionsDataSource.paginator`, `pageSizeOptions`).
- Reorganiza o template para a ordem: filtros → card da inspeção selecionada → lista de fotos → lista de inspeções encontradas (HTML reorganizado em `inspection-search.component.html`).
- Inclui botão `Editar` em cada foto e um editor inline de metadados (descrição e `photoUrl`) com ações `Salvar`/`Cancelar` na UI (`inspection-search.component.ts`/`.html`/`.scss`).
- Adiciona no service um método `updatePhotoInspectionMetadata(photo: PhotoInspection)` para atualizar apenas os metadados de foto sem enviar arquivo binário (`inspection.service.ts`).

### Testing
- Executado `npm run build -- --configuration development` e o build obteve sucesso (output em `dist/`), validação aprovada.
- Executado `npm run build` (produção) falhou no ambiente por causa de inlining de fontes externas (Google Fonts retornando HTTP 403), problema externo ao código e não relacionado às mudanças.
- Nenhum teste unitário adicional foi alterado; mudanças foram verificadas compilando a aplicação em modo de desenvolvimento.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be2ed9b37c83228c1dc916a58a47c2)