### PR TITLE
feat: adicionar menu Fotos com CRUD e substituição de arquivo na edição

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -88,9 +88,14 @@ export const routes: Routes = [
   },
   {
     path: 'photos-inspections',
+    redirectTo: 'photos',
+    pathMatch: 'full'
+  },
+  {
+    path: 'photos',
     component: InspectionImportListComponent,
     canActivate: [AuthGuard],
-    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], view: 'photos-inspections' }
+    data: { roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'], view: 'photos' }
   },
   {
     path: 'inspection-upload',

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.html
@@ -2,6 +2,7 @@
   <h2 *ngIf="viewMode === 'inspections'">Gestão de inspeções</h2>
   <h2 *ngIf="viewMode === 'inspectors'">Cadastro de inspetor</h2>
   <h2 *ngIf="viewMode === 'photos-inspections'">Fotos de inspeções</h2>
+  <h2 *ngIf="viewMode === 'photos'">Fotos</h2>
   <h2 *ngIf="viewMode === 'inspection-upload'">Upload de inspeção</h2>
 
   <div *ngIf="viewMode === 'inspections'" class="page-content">
@@ -181,7 +182,33 @@
       </table>
     </div>
   </div>
-  <div *ngIf="viewMode === 'photos-inspections'" class="page-content">
+  <div *ngIf="viewMode === 'photos-inspections' || viewMode === 'photos'" class="page-content">
+    <div class="editor-box mat-elevation-z2">
+      <h3>Cadastrar foto</h3>
+      <div class="form-grid">
+        <mat-form-field appearance="outline">
+          <mat-label>Inspeção</mat-label>
+          <mat-select [(ngModel)]="newPhotoInspectionId">
+            <mat-option *ngFor="let inspection of dataSource.data" [value]="inspection.id">
+              #{{ inspection.id }} - {{ inspection.client || inspection.name || 'Sem cliente' }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Descrição</mat-label>
+          <input matInput [(ngModel)]="newPhotoDescription" />
+        </mat-form-field>
+      </div>
+
+      <input type="file" accept="image/*" (change)="onNewPhotoFileSelected($event)" />
+
+      <div class="actions-row">
+        <button mat-raised-button color="primary" (click)="createPhoto()">Cadastrar foto</button>
+        <button mat-stroked-button (click)="clearCreatePhotoForm()">Limpar</button>
+      </div>
+    </div>
+
     <div class="photo-filters-row">
       <mat-form-field appearance="outline" class="filter-field">
         <mat-label>Filtrar por inspetor</mat-label>
@@ -243,7 +270,8 @@
           <th mat-header-cell *matHeaderCellDef>Ações</th>
           <td mat-cell *matCellDef="let row">
             <div class="actions-cell">
-              <button mat-stroked-button color="primary" (click)="startEditPhoto(row)">Alterar foto</button>
+              <button mat-stroked-button (click)="openPhotoPreview(row)">Visualizar</button>
+              <button mat-stroked-button color="primary" (click)="startEditPhoto(row)">Editar</button>
               <button mat-stroked-button color="warn" (click)="deletePhoto(row)">Excluir</button>
             </div>
           </td>
@@ -255,7 +283,8 @@
     </div>
 
     <div class="editor-box mat-elevation-z2" *ngIf="photoEditing">
-      <h3>Alterar foto #{{ photoEditing.id }}</h3>
+      <h3>Editar foto #{{ photoEditing.id }}</h3>
+      <p>Selecione uma nova imagem para substituir o arquivo da foto neste mesmo registro.</p>
       <div class="form-grid one-column">
         <mat-form-field appearance="outline">
           <mat-label>Descrição</mat-label>
@@ -266,6 +295,15 @@
       <div class="actions-row">
         <button mat-raised-button color="primary" (click)="savePhotoChanges()">Salvar</button>
         <button mat-stroked-button (click)="cancelEditPhoto()">Cancelar</button>
+      </div>
+    </div>
+
+    <div class="photo-modal" *ngIf="selectedPhotoPreview" (click)="closePhotoPreview()">
+      <div class="photo-modal-content" (click)="$event.stopPropagation()">
+        <button mat-icon-button class="close-button" (click)="closePhotoPreview()" aria-label="Fechar popup">
+          <mat-icon>close</mat-icon>
+        </button>
+        <img [src]="selectedPhotoPreview" alt="Foto da inspeção" />
       </div>
     </div>
   </div>

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.scss
@@ -96,3 +96,36 @@ table {
   border-radius: 8px;
   border: 1px solid #ddd;
 }
+
+.photo-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+}
+
+.photo-modal-content {
+  position: relative;
+  background: #fff;
+  border-radius: 10px;
+  max-width: min(90vw, 980px);
+  max-height: 90vh;
+  padding: 12px;
+}
+
+.photo-modal-content img {
+  width: 100%;
+  max-height: calc(90vh - 24px);
+  object-fit: contain;
+  border-radius: 8px;
+}
+
+.close-button {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background-color: rgba(255, 255, 255, 0.8);
+}

--- a/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
+++ b/src/app/components/inspection/inspection-import-list/inspection-import-list.component.ts
@@ -45,7 +45,7 @@ import { AuthService } from '../../../auth/services/auth.service';
   styleUrl: './inspection-import-list.component.scss'
 })
 export class InspectionImportListComponent implements AfterViewInit {
-  viewMode: 'inspections' | 'inspectors' | 'photos-inspections' | 'inspection-upload' = 'inspections';
+  viewMode: 'inspections' | 'inspectors' | 'photos-inspections' | 'photos' | 'inspection-upload' = 'inspections';
   readonly canManageInspectors: boolean;
   inspectionColumns: string[] = ['id', 'status', 'worder', 'client', 'name', 'city', 'duedate', 'actions'];
   inspectorColumns: string[] = ['id', 'nome', 'actions'];
@@ -73,6 +73,10 @@ export class InspectionImportListComponent implements AfterViewInit {
   inspectorEditing?: Inspector;
   photoEditing?: PhotoInspection;
   selectedPhotoFileForUpdate?: File;
+  selectedPhotoPreview?: string;
+  newPhotoInspectionId?: number;
+  newPhotoDescription = '';
+  newPhotoFile?: File;
 
   inspectorForm: Inspector = { nome: '' };
 
@@ -94,6 +98,10 @@ export class InspectionImportListComponent implements AfterViewInit {
 
     if (routeView === 'photos-inspections') {
       this.viewMode = 'photos-inspections';
+    }
+
+    if (routeView === 'photos') {
+      this.viewMode = 'photos';
     }
 
     if (routeView === 'inspection-upload') {
@@ -374,6 +382,50 @@ export class InspectionImportListComponent implements AfterViewInit {
     this.selectedPhotoFileForUpdate = input.files?.[0];
   }
 
+  onNewPhotoFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.newPhotoFile = input.files?.[0];
+  }
+
+  createPhoto(): void {
+    if (!this.newPhotoInspectionId || !this.newPhotoFile) {
+      this.showMessage('Selecione a inspeção e uma imagem para cadastrar a foto.');
+      return;
+    }
+
+    this.inspectionService
+      .createPhotoInspection(this.newPhotoInspectionId, this.newPhotoFile, this.newPhotoDescription || '')
+      .subscribe({
+        next: () => {
+          this.showMessage('Foto cadastrada com sucesso.');
+          this.clearCreatePhotoForm();
+          this.loadPhotosInspections();
+        },
+        error: () => this.showMessage('Não foi possível cadastrar a foto.')
+      });
+  }
+
+  clearCreatePhotoForm(): void {
+    this.newPhotoInspectionId = undefined;
+    this.newPhotoDescription = '';
+    this.newPhotoFile = undefined;
+  }
+
+  openPhotoPreview(row: PhotoInspection): void {
+    const preview = this.getPhotoPreview(row);
+
+    if (!preview) {
+      this.showMessage('Foto sem visualização disponível.');
+      return;
+    }
+
+    this.selectedPhotoPreview = preview;
+  }
+
+  closePhotoPreview(): void {
+    this.selectedPhotoPreview = undefined;
+  }
+
   startEditPhoto(row: PhotoInspection): void {
     this.photoEditing = { ...row };
     this.selectedPhotoFileForUpdate = undefined;
@@ -394,7 +446,7 @@ export class InspectionImportListComponent implements AfterViewInit {
       .updatePhotoInspection(this.photoEditing.id, this.selectedPhotoFileForUpdate, this.photoEditing.descricao || '')
       .subscribe({
         next: () => {
-          this.showMessage('Foto atualizada com sucesso.');
+          this.showMessage('Foto substituída com sucesso.');
           this.cancelEditPhoto();
           this.loadPhotosInspections();
         },

--- a/src/app/components/inspection/inspection-search/inspection-search.component.html
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.html
@@ -86,23 +86,20 @@
   </div>
 
   <div class="photo-editor mat-elevation-z2" *ngIf="photoEditing">
-    <h3>Editar metadados da foto #{{ photoEditing.id }}</h3>
+    <h3>Editar foto #{{ photoEditing.id }}</h3>
+    <p class="helper-text">Selecione uma nova imagem para substituir o arquivo da foto neste mesmo registro.</p>
 
     <div class="photo-editor-fields">
       <mat-form-field appearance="outline">
         <mat-label>Descrição</mat-label>
         <input matInput [(ngModel)]="photoEditing.descricao" />
       </mat-form-field>
-
-      <mat-form-field appearance="outline">
-        <mat-label>URL da foto</mat-label>
-        <input matInput [(ngModel)]="photoEditing.photoUrl" />
-      </mat-form-field>
     </div>
+    <input type="file" accept="image/*" (change)="onPhotoFileForUpdateSelected($event)" />
 
     <div class="actions-row">
-      <button mat-raised-button color="primary" (click)="savePhotoMetadata()" [disabled]="isSavingPhoto">
-        Salvar
+      <button mat-raised-button color="primary" (click)="savePhotoReplacement()" [disabled]="isSavingPhoto">
+        Salvar substituição
       </button>
       <button mat-stroked-button (click)="cancelEditPhoto()" [disabled]="isSavingPhoto">
         Cancelar

--- a/src/app/components/inspection/inspection-search/inspection-search.component.ts
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.ts
@@ -53,6 +53,7 @@ export class InspectionSearchComponent implements OnInit, AfterViewInit {
   selectedInspection?: Inspection;
   selectedPhotoPreview?: string;
   photoEditing?: PhotoInspection;
+  selectedPhotoFileForUpdate?: File;
   isSavingPhoto = false;
   readonly pageSizeOptions = [5, 10, 15, 20];
 
@@ -180,20 +181,28 @@ export class InspectionSearchComponent implements OnInit, AfterViewInit {
 
   startEditPhoto(photo: PhotoInspection): void {
     this.photoEditing = { ...photo };
+    this.selectedPhotoFileForUpdate = undefined;
   }
 
   cancelEditPhoto(): void {
     this.photoEditing = undefined;
+    this.selectedPhotoFileForUpdate = undefined;
   }
 
-  savePhotoMetadata(): void {
-    if (!this.photoEditing) {
+  onPhotoFileForUpdateSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedPhotoFileForUpdate = input.files?.[0];
+  }
+
+  savePhotoReplacement(): void {
+    if (!this.photoEditing?.id || !this.selectedPhotoFileForUpdate) {
+      this.showMessage('Selecione uma nova imagem para substituir a foto atual.');
       return;
     }
 
     this.isSavingPhoto = true;
     this.inspectionService
-      .updatePhotoInspectionMetadata(this.photoEditing)
+      .updatePhotoInspection(this.photoEditing.id, this.selectedPhotoFileForUpdate, this.photoEditing.descricao || '')
       .pipe(finalize(() => (this.isSavingPhoto = false)))
       .subscribe({
         next: (updatedPhoto) => {
@@ -201,9 +210,10 @@ export class InspectionSearchComponent implements OnInit, AfterViewInit {
             photo.id === updatedPhoto.id ? { ...photo, ...updatedPhoto } : photo
           );
           this.photoEditing = undefined;
-          this.showMessage('Dados da foto atualizados com sucesso.');
+          this.selectedPhotoFileForUpdate = undefined;
+          this.showMessage('Foto substituída com sucesso.');
         },
-        error: () => this.showMessage('Não foi possível atualizar os dados da foto.')
+        error: () => this.showMessage('Não foi possível substituir a foto.')
       });
   }
 

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -93,6 +93,18 @@ export class InspectionService {
     return this.http.post<PhotoInspection[]>(`${this.photosInspectionsApiUrl}/by-inspections`, inspections);
   }
 
+  createPhotoInspection(inspectionId: number, photoFile: File, descricao?: string): Observable<PhotoInspection> {
+    const formData = new FormData();
+    formData.append('inspectionId', String(inspectionId));
+    formData.append('foto', photoFile);
+
+    if (descricao !== undefined && descricao !== null) {
+      formData.append('descricao', descricao);
+    }
+
+    return this.http.post<PhotoInspection>(this.photosInspectionsApiUrl, formData);
+  }
+
   updatePhotoInspection(id: number, photoFile: File, descricao?: string): Observable<PhotoInspection> {
     const formData = new FormData();
     formData.append('foto', photoFile);

--- a/src/app/components/template/nav/nav.component.ts
+++ b/src/app/components/template/nav/nav.component.ts
@@ -35,7 +35,7 @@ export class NavComponent {
     { label: 'Início', icon: 'home', route: '/dashboard', roles: ['ROLE_ADMIN', 'ROLE_USER', 'ROLE_CORRETOR'] },
     { label: 'Inspeções', icon: 'fact_check', route: '/inspections', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Cadastro de inspetor', icon: 'badge', route: '/inspectors', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
-    { label: 'Fotos de inspeções', icon: 'photo_library', route: '/photos-inspections', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
+    { label: 'Fotos', icon: 'photo_library', route: '/photos', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Upload de inspeção', icon: 'folder_zip', route: '/inspection-upload', roles: ['ROLE_ADMIN', 'ROLE_CORRETOR'] },
     { label: 'Usuários', icon: 'people', route: '/users', roles: ['ROLE_ADMIN'] },
     { label: 'Cadastrar Usuário', icon: 'person_add', route: '/register', roles: ['ROLE_ADMIN'] }  ];


### PR DESCRIPTION
### Motivation
- Permitir que o botão de editar foto substitua o arquivo da imagem no mesmo registro em vez de alterar apenas metadados. 
- Fornecer um CRUD dedicado para fotos com telas de cadastro, listagem, visualização, edição (substituição de arquivo) e exclusão. 

### Description
- Ajusta a tela de pesquisa de inspeções para que a edição de foto exija upload de nova imagem e chame `updatePhotoInspection` para substituir o arquivo; alterações em `src/app/components/inspection/inspection-search/*`. 
- Adiciona endpoint de criação de foto com `createPhotoInspection` usando `FormData` em `src/app/components/inspection/inspection.service.ts`. 
- Estende a tela de fotos (`InspectionImportListComponent`) para suportar cadastro (`createPhoto`), visualização em modal, edição com substituição de arquivo e exclusão em `src/app/components/inspection/inspection-import-list/*`. 
- Cria rota e menu `Fotos` em `/photos`, adiciona redirecionamento de `/photos-inspections` para `/photos` e atualiza o menu (`src/app/app.routes.ts`, `src/app/components/template/nav/nav.component.ts`). 

### Testing
- Executado `npm run build` que falhou devido a bloqueio externo na tentativa de inline de Google Fonts (`403`), não relacionado ao código alterado. 
- Executado `npm run build -- --configuration development` que completou com sucesso e gerou os bundles em `dist/crm-security-front`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be32072b4c83228ff65394831d7d18)