### PR TITLE
Carregar OTypes via API com dropdown pesquisável

### DIFF
--- a/src/app/components/inspection/inspection-search/inspection-search.component.html
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.html
@@ -12,7 +12,7 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" *ngIf="searchMode === 'worder'; else otypeField">
       <mat-label>{{ searchLabel }}</mat-label>
       <input
         matInput
@@ -21,6 +21,25 @@
         (keydown)="onKeydownSearch($event)"
       />
     </mat-form-field>
+    <ng-template #otypeField>
+      <mat-form-field appearance="outline">
+        <mat-label>{{ searchLabel }}</mat-label>
+        <input
+          matInput
+          [(ngModel)]="searchValue"
+          [placeholder]="searchPlaceholder"
+          [matAutocomplete]="otypeAutocomplete"
+          [disabled]="isLoadingOtypes"
+          (keydown)="onKeydownSearch($event)"
+        />
+        <mat-hint *ngIf="isLoadingOtypes">Carregando OTypes...</mat-hint>
+        <mat-autocomplete #otypeAutocomplete="matAutocomplete">
+          <mat-option *ngFor="let otype of filteredOtypes" [value]="otype">
+            {{ otype }}
+          </mat-option>
+        </mat-autocomplete>
+      </mat-form-field>
+    </ng-template>
 
     <div class="actions-row">
       <button mat-raised-button color="primary" (click)="search()" [disabled]="isLoading">

--- a/src/app/components/inspection/inspection-search/inspection-search.component.ts
+++ b/src/app/components/inspection/inspection-search/inspection-search.component.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
@@ -27,6 +28,7 @@ import { InspectionService } from '../inspection.service';
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    MatAutocompleteModule,
     MatSelectModule,
     MatSnackBarModule,
     MatPaginatorModule,
@@ -43,9 +45,11 @@ export class InspectionSearchComponent implements OnInit, AfterViewInit {
   inspectorId?: number;
   searchValue = '';
   isLoading = false;
+  isLoadingOtypes = false;
   isLoadingPhotos = false;
 
   inspectors: Inspector[] = [];
+  otypes: string[] = [];
   inspectionsDataSource = new MatTableDataSource<Inspection>([]);
   photosDataSource = new MatTableDataSource<PhotoInspection>([]);
 
@@ -100,6 +104,7 @@ export class InspectionSearchComponent implements OnInit, AfterViewInit {
     const mode = this.route.snapshot.data['mode'];
     if (mode === 'otype') {
       this.searchMode = 'otype';
+      this.loadOtypes();
     }
 
     this.loadInspectors();
@@ -118,7 +123,16 @@ export class InspectionSearchComponent implements OnInit, AfterViewInit {
   }
 
   get searchPlaceholder(): string {
-    return this.searchMode === 'worder' ? 'Digite o worder' : 'Digite o otype';
+    return this.searchMode === 'worder' ? 'Digite o worder' : 'Selecione ou digite um otype';
+  }
+
+  get filteredOtypes(): string[] {
+    const search = this.searchValue.trim().toLocaleLowerCase();
+    if (!search) {
+      return this.otypes;
+    }
+
+    return this.otypes.filter((otype) => otype.toLocaleLowerCase().includes(search));
   }
 
   loadInspectors(): void {
@@ -128,6 +142,21 @@ export class InspectionSearchComponent implements OnInit, AfterViewInit {
       },
       error: () => this.showMessage('Não foi possível carregar os inspetores.')
     });
+  }
+
+  loadOtypes(): void {
+    this.isLoadingOtypes = true;
+    this.inspectionService
+      .listOtypes()
+      .pipe(finalize(() => (this.isLoadingOtypes = false)))
+      .subscribe({
+        next: (otypes) => {
+          this.otypes = otypes
+            .map((otype) => otype?.trim())
+            .filter((otype): otype is string => Boolean(otype));
+        },
+        error: () => this.showMessage('Não foi possível carregar os otypes.')
+      });
   }
 
   search(): void {

--- a/src/app/components/inspection/inspection.service.ts
+++ b/src/app/components/inspection/inspection.service.ts
@@ -51,6 +51,10 @@ export class InspectionService {
     return this.http.get<Inspection[]>(`${this.inspectionsApiUrl}/por-otype`, { params });
   }
 
+  listOtypes(): Observable<string[]> {
+    return this.http.get<string[]>(`${this.inspectionsApiUrl}/otypes`);
+  }
+
   uploadExcel(file: File): Observable<void> {
     const formData = new FormData();
     formData.append('file', file);


### PR DESCRIPTION
### Motivation
- Tornar a lista de OTypes dinâmica e pesquisável, removendo valores fixos no frontend e usando o backend como fonte única de verdade via `GET /api/inspections/otypes`.

### Description
- Adicionado `listOtypes()` em `InspectionService` para consumir `GET /api/inspections/otypes`.
- Na `InspectionSearchComponent` foram inseridos `otypes: string[]`, `isLoadingOtypes`, o método `loadOtypes()` e o getter `filteredOtypes()` para normalizar, armazenar e filtrar os valores retornados.
- Substituído o campo de OType por um campo com `mat-autocomplete` no template `inspection-search.component.html`, permitindo digitação livre e seleção a partir da lista filtrada; também exibido um hint de carregamento enquanto os OTypes são buscados.

### Testing
- Executado `npm run build -- --configuration development` com sucesso e bundle gerado (output em `/dist/crm-security-front`).
- Executado `npm run build` (build de produção) falhou no ambiente devido a erro externo de inlining de fontes do Google Fonts (HTTP 403), que não está relacionado às alterações funcionais feitas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3ae7207c8322b03500f232428436)