### PR TITLE
Melhora legibilidade das opções no menu lateral

### DIFF
--- a/src/app/components/template/nav/nav.component.css
+++ b/src/app/components/template/nav/nav.component.css
@@ -1,15 +1,30 @@
 .sidenav{
     background-color: #3f51b5;
-    width: 200px;
+    width: 280px;
+    overflow-y: auto;
 
 }
 
 .sidenav a{
     color: #fff;
+    white-space: normal;
+    line-height: 1.3;
 }
 
 .sidenav i{
     padding-right: 10px;
+}
+
+.sidenav .mat-mdc-list-item {
+    min-height: 48px;
+    height: auto !important;
+    align-items: center;
+}
+
+.sidenav .mdc-list-item__content {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
 }
 
 .submenu-arrow {
@@ -28,4 +43,3 @@
     padding: 16px;
     background-color: #fff;
 }
-


### PR DESCRIPTION
### Motivation
- Tornar todas as opções do menu lateral legíveis e acessíveis mesmo quando os rótulos são longos.
- Evitar que itens do menu sejam cortados ou escondidos quando a lista excede a altura da tela.

### Description
- Aumentei a largura do `sidenav` de `200px` para `280px` para acomodar labels maiores no menu lateral (`src/app/components/template/nav/nav.component.css`).
- Adicionei `overflow-y: auto` ao `sidenav` para permitir rolagem vertical quando houver muitas opções.
- Permiti quebra de linha e ajuste de espaçamento nos links do menu com `white-space: normal` e `line-height: 1.3` para melhorar a legibilidade.
- Ajustei os estilos específicos do `mat-list` (`.mat-mdc-list-item` e `.mdc-list-item__content`) para altura automática, conteúdo sem truncamento e remoção de `text-overflow` para que textos longos sejam exibidos corretamente.

### Testing
- Executei o build com `npm run build`, que falhou por uma limitação do ambiente de CI local: a etapa de inlining de fontes falhou com um `403` ao buscar o Roboto do Google Fonts; não foi possível concluir o build end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3dd3324c8322b47337fa05ef7dd3)