### PR TITLE
Configure environment URLs for dev (localhost) and production (AWS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ Sistema CRM desenvolvido para otimizar processos de captação, gestão e acompa
 Para rodar frontend e backend juntos em ambiente local sem erro de CORS:
 
 1. Suba o backend Spring Security em `http://localhost:8080`.
-2. Suba o frontend Angular com `npm start` (ou `ng serve`).
-3. O Angular usa `proxy.conf.json` para redirecionar automaticamente chamadas `/auth` e `/api` para o backend Java.
+2. Garanta que o arquivo `src/environments/environment.development.ts` esteja com `apiBaseUrl: 'http://localhost:8080'`.
+3. Suba o frontend Angular com `npm start` (ou `ng serve`).
 
-Isso permite manter chamadas HTTP relativas no frontend (ex.: `/auth/login`, `/api/users`) e simplifica a integração entre os dois projetos.
+Para deploy em produção (AWS), configure o endpoint do backend em `src/environments/environment.ts` no campo `apiBaseUrl`.
+
+Isso permite manter uma configuração separada por ambiente (dev/prod), exatamente como no padrão usado com backend Spring.
 
 ---
 ## 🏗️ Tecnologias Utilizadas

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiBaseUrl: ''
+  apiBaseUrl: 'http://localhost:8080'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiBaseUrl: ''
+  apiBaseUrl: 'https://SEU-BACKEND-AWS.amazonaws.com'
 };


### PR DESCRIPTION
### Motivation
- Separate API endpoints for development and production so the frontend can use `http://localhost:8080` during local development and a configurable AWS endpoint in production.

### Description
- Set `src/environments/environment.development.ts` to `apiBaseUrl: 'http://localhost:8080'` for local development.
- Set `src/environments/environment.ts` to `apiBaseUrl: 'https://SEU-BACKEND-AWS.amazonaws.com'` as a placeholder production endpoint to be replaced with the real AWS URL.
- Update `README.md` to document the dev file usage and instruct how to configure the production backend URL.

### Testing
- Ran the production build with `npm run build`, which failed due to an external Google Fonts inlining error (HTTP 403) unrelated to the environment variable changes.
- No automated unit tests were added or modified; files `src/environments/environment.ts`, `src/environments/environment.development.ts`, and `README.md` were verified updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c019055e048322925a13fd900cb502)