### PR TITLE
fix(auth): use /auth base path for login endpoints

### DIFF
--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -8,7 +8,8 @@ import { environment } from '../../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly apiBaseUrl = environment.apiBaseUrl;
-  private readonly authApiUrl = `${this.apiBaseUrl}/auth`;
+  private readonly authBaseUrl = this.apiBaseUrl.replace(/\/api\/?$/, '');
+  private readonly authApiUrl = `${this.authBaseUrl}/auth`;
   private readonly usersApiUrl = `${this.apiBaseUrl}/api/users`;
   private readonly permissionsApiUrl = `${this.apiBaseUrl}/api/permissions`;
 


### PR DESCRIPTION
### Motivation
- Ensure authentication requests target `/auth/login` (for example `http://13.59.151.66:8080/auth/login`) instead of `/api/auth/login` while keeping other API endpoints unchanged.

### Description
- In `src/app/auth/services/auth.service.ts` compute an `authBaseUrl` from `environment.apiBaseUrl` by stripping a trailing `/api` with `environment.apiBaseUrl.replace(/\/api\/?$/, '')` and use it to build `authApiUrl` as ```${this.authBaseUrl}/auth``` while leaving `usersApiUrl` and `permissionsApiUrl` pointing at the original `apiBaseUrl`.

### Testing
- Ran `npm run build`, which failed in this environment due to external Google Fonts inlining returning HTTP 403 and not because of the code change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0405221888322a0938a5056728c7b)