### PR TITLE
chore: point frontend API base URL to 13.59.151.66:8080

### DIFF
--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8080'
+  apiBaseUrl: 'http://13.59.151.66:8080'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiBaseUrl: '/api'
+  apiBaseUrl: 'http://13.59.151.66:8080'
 };


### PR DESCRIPTION
### Motivation
- Point the frontend configuration to a specific backend host and port so the app calls the API at `http://13.59.151.66:8080` instead of localhost or the `/api` proxy.

### Description
- Update `apiBaseUrl` in `src/environments/environment.development.ts` and `src/environments/environment.ts` to `'http://13.59.151.66:8080'` so both development and production builds target the same host:port.

### Testing
- Ran `npm run build`, which failed in this environment due to Google Fonts inlining returning HTTP 403, so no successful production build could be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c043767f1c83228f37fa00c68483db)